### PR TITLE
Enhancement of the ListenAndServe method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ of.HandleFunc(of.TypeHello, func(rw of.ResponseWriter, r *of.Request) {
 })
 
 // Start the TCP server on 6633 port.
-of.ListenAndServe()
+of.ListenAndServe(":6633", nil)
 ```
 
 ```go

--- a/examples/hub.go
+++ b/examples/hub.go
@@ -49,5 +49,5 @@ func main() {
 	})
 
 	log.Println("started listening...")
-	of.ListenAndServe()
+	of.ListenAndServe(":6633", nil)
 }


### PR DESCRIPTION
This patch modifies the signature of the method ListenAndServer,
so it could accept the address where listen and the handler to use.

Fixes issue #2.