### PR TITLE
Refactoring of OpenFlow actions.

### DIFF
--- a/ofp.v13/action.go
+++ b/ofp.v13/action.go
@@ -8,75 +8,86 @@ import (
 )
 
 const (
-	// Output to switch port.
-	AT_OUTPUT ActionType = iota
+	// ActionTypeOutput outputs the packet to the switch port.
+	ActionTypeOutput ActionType = iota
 
-	// Copy TTL "outwards", from next-to-outermost to outermost.
-	AT_COPY_TTL_OUT ActionType = 10 + iota
+	// ActionTypeCopyTTLOut copies the TTL from the next-to-outermost header
+	// to outermost header with TTL.
+	ActionTypeCopyTTLOut ActionType = 10 + iota
 
-	// Copy TTL "inwards" -- from outermost to next-to-outermost.
-	AT_COPY_TTL_IN ActionType = 10 + iota
+	// ActionTypeCopyTTLIn copies the TTL from the outermost header to the
+	// next-to-outermost header with TTL.
+	ActionTypeCopyTTLIn ActionType = 10 + iota
 
-	// MPLS TTL.
-	AT_SET_MPLS_TTL ActionType = 12 + iota
+	// ActionTypeSetMPLSTTL replaces the existing MTPL TTL. This applies
+	// only to the packets with existing MPLS shim header.
+	ActionTypeSetMPLSTTL ActionType = 12 + iota
 
-	// Decrement MPLS TTL.
-	AT_DEC_MPLS_TTL ActionType = 12 + iota
+	// ActionTypeDecMPLSTTL decrements the MTPS TTL. This applies only to
+	// the packets with existing MPLS shim header.
+	ActionTypeDecMPLSTTL ActionType = 12 + iota
 
-	// Push a new VLAN tag.
-	AT_PUSH_VLAN ActionType = 12 + iota
+	// ActionTypePushVLAN pushes a new VLAN header onto the packet.
+	ActionTypePushVLAN ActionType = 12 + iota
 
-	// Pop the outer VLAN tag.
-	AT_POP_VLAN ActionType = 12 + iota
+	// ActionTypePopVLAN pops the outer-most VLAN header from the packet.
+	ActionTypePopVLAN ActionType = 12 + iota
 
-	// Push a new MPLS tag.
-	AT_PUSH_MPLS ActionType = 12 + iota
+	// ActionTypePushMPLS pushes a new MPLS shim header onto the packet.
+	ActionTypePushMPLS ActionType = 12 + iota
 
-	// Pop the outer MPLS tag.
-	AT_POP_MPLS ActionType = 12 + iota
+	// ActionTypePopMPLS pops the outer-most MPLS tag or shim header from
+	// the packet.
+	ActionTypePopMPLS ActionType = 12 + iota
 
-	// Set queue id when outputting to a port.
-	AT_SET_QUEUE ActionType = 12 + iota
+	// ActionTypeSetQueue specifies on which queue attached to the port
+	// should be used to queue and forward packet.
+	ActionTypeSetQueue ActionType = 12 + iota
 
-	// Apply group.
-	AT_GROUP ActionType = 12 + iota
+	// ActionTypeGroup specifies that action should be set to the group
+	// action, when a packet has to be processed by the group table.
+	ActionTypeGroup ActionType = 12 + iota
 
-	// IP TTL.
-	AT_SET_NW_TTL ActionType = 12 + iota
+	// ActionTypeSetNwTTL replaces the existing IPv4 TTL or IPv6 Hop Limit
+	// and updates the IP checksum.
+	ActionTypeSetNwTTL ActionType = 12 + iota
 
-	// Decrement IP TTL.
-	AT_DEC_NW_TTL ActionType = 12 + iota
+	// ActionTypeDecNwTTL decrements the IPv4 TTL or IPv6 Hop Limit and
+	// and updates the IP checksum.
+	ActionTypeDecNwTTL ActionType = 12 + iota
 
-	// Set a header field using OXM TLV format.
-	AT_SET_FIELD ActionType = 12 + iota
+	// ActionTypeSetField sets the value to the packet field.
+	ActionTypeSetField ActionType = 12 + iota
 
-	// Push a new PBB service tag (I-TAG).
-	AT_PUSH_PBB ActionType = 12 + iota
+	// ActionTypePushPBB pushes a new PBB service instance header (I-TAG)
+	// onto the packet.
+	ActionTypePushPBB ActionType = 12 + iota
 
-	// Pop the outer PBB service tag (I-TAG).
-	AT_POP_PBB ActionType = 12 + iota
+	// ActionTypePopPBB pops the outer-most PBB service instance header
+	// (I-TAG) from the packet.
+	ActionTypePopPBB ActionType = 12 + iota
 
-	// Experimetal.
-	AT_EXPERIMENTER ActionType = 0xffff
+	// ActionTypeExperimenter applies the experimental action.
+	ActionTypeExperimenter ActionType = 0xffff
 )
 
+// ActionType specifies the action type.
 type ActionType uint16
 
 const (
-	// Maximum MaxLength value which can be used to request a specific byte
-	// length.
-	CML_MAX uint16 = 0xffe5
+	// ContentLenMax defines the maximum length of the bytes, that should
+	// be submitted to the controller on output action type.
+	ContentLenMax uint16 = 0xffe5
 
-	// Indicates that no buffering should be applied and the whole packet is
-	// to be sent to the controller.
-	CML_NO_BUFFER uint16 = 0xffff
+	// ContentLenNoBuffer indicates that no buffering should be applied and
+	// the whole packet is to be sent to the controller on output action type.
+	ContentLenNoBuffer uint16 = 0xffff
 )
 
 type actionhdr struct {
 	Type ActionType
 
-	// Length of action, including this header. This is the length of action,
-	// including any padding to make it 64-bit aligned
+	// Length of action, including this header.
 	Len uint16
 }
 
@@ -84,8 +95,10 @@ type action interface {
 	io.WriterTo
 }
 
+// Actions groups the set of actions.
 type Actions []action
 
+// WriteTo writes the list of action to the given writer instance.
 func (a Actions) WriteTo(w io.Writer) (n int64, err error) {
 	var buf bytes.Buffer
 
@@ -99,127 +112,157 @@ func (a Actions) WriteTo(w io.Writer) (n int64, err error) {
 	return binary.Write(w, binary.BigEndian, buf.Bytes())
 }
 
-// Action header that is common to all actions. The length includes the
-// header and any padding used to make the action 64-bit aligned.
-// NB: The length of an action *must* always be a multiple of eight.
+// Action is header that is common to all actions. The length includes
+// the header and any padding used to make the action 64-bit aligned.
 type Action struct {
+	// Type specified type of the action.
 	Type ActionType
 }
 
+// WriteTo implements io.WriterTo interface. It serializes the action
+// with a necessary padding.
 func (a Action) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
 		actionhdr{a.Type, 8}, pad4{},
 	})
 }
 
-// Action structure for PAT_OUTPUT, which sends packets out port.
-// When the port is the PP_CONTROLLER, MaxLen indicates the max
-// number of bytes to send. A MaxLen of zero means no bytes of the
-// packet should be sent. A MaxLen of CML_NO_BUFFER means that
-// the packet is not buffered and the complete packet is to be sent to
-// the controller.
+// ActionOutput is an action used to output the packets to the switch port.
+//
+// When the port is the PortController, MaxLen indicates the max number of
+// bytes to send. A MaxLen of zero means no bytes of the packet should be
+// sent.
+//
+// A MaxLen of ContentLenNoBuffer means that the packet is not buffered and
+// the complete packet is to be sent to the controller.
 type ActionOutput struct {
-	// Output port
+	// Output port.
 	Port PortNo
-	// Max length to send to controller
+
+	// Max length to send to controller.
 	MaxLen uint16
 }
 
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
 func (a ActionOutput) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
-		actionhdr{AT_OUTPUT, 16}, a, pad6{},
+		actionhdr{ActionTypeOutput, 16}, a, pad6{},
 	})
 }
 
-// Action structure for PAT_GROUP
+// ActionGroup is an action that specifis the group used to process
+// the packet.
 type ActionGroup struct {
-	// The group_id indicates the group used to process this packet.
+	// The GroupID indicates the group used to process this packet.
 	// The set of buckets to apply depends on the group type.
-	GroupID uint32
+	GroupID Group
 }
 
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
 func (a ActionGroup) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
-		actionhdr{AT_GROUP, 8}, a,
+		actionhdr{ActionTypeGroup, 8}, a,
 	})
 }
 
-// ActionSetQueue sets the queue id that will be used to map a
-// flow entry to an already-configured queue on a port,
-// regardless of the ToS and VLAN PCP bits. The packet should not change as a result
-// of a Set-Queue action. If the switch needs to set the
-// ToS/PCP bits for internal handling, the original values should
-// be restored before sending the packet out.
+// ActionSetQueue sets the queue ID that will be used to map a flow entry
+// to an already-configured queue on a port, regardless of the ToS and VLAN
+// PCP bits.
+//
+// The packet should not change as a result of a Set-Queue action. If the
+// switch needs to set the ToS/PCP bits for internal handling, the original
+// values should be restored before sending the packet out.
 type ActionSetQueue struct {
-	QueueID uint32
+	// The QueueID indicates the queue used to forward the packet.
+	QueueID Queue
 }
 
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
 func (a ActionSetQueue) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
-		actionhdr{AT_SET_QUEUE, 8}, a,
+		actionhdr{ActionTypeSetQueue, 8}, a,
 	})
 }
 
-// Action structure for PAT_SET_MPLS_TTL
-type ActionMPLSTTL struct {
+// ActionSetMPLSTTL is an action used to replace the MPLS TTL
+// value of the processing packet.
+type ActionSetMPLSTTL struct {
 	// The TTL field is the MPLS TTL to set
 	TTL uint8
 }
 
-func (a ActionMPLSTTL) WriteTo(w io.Writer) (int64, error) {
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
+func (a ActionSetMPLSTTL) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
-		actionhdr{AT_SET_MPLS_TTL, 8}, a, pad3{},
+		actionhdr{ActionTypeSetMPLSTTL, 8}, a, pad3{},
 	})
 }
 
-// Action structure for PAT_SET_NW_TTL
+// ActionSetNetworkTTL is an action used to replace the network
+// TTL of the processing packet.
 type ActionSetNetworkTTL struct {
 	// The TTL field is the TTL address to set in the IP header.
 	TTL uint8
 }
 
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
 func (a ActionSetNetworkTTL) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
-		actionhdr{AT_SET_NW_TTL, 8}, a, pad3{},
+		actionhdr{ActionTypeSetNwTTL, 8}, a, pad3{},
 	})
 }
 
-// Action structure for PAT_PUSH_VLAN/MPLS/PBB
+// ActionPush is an action used to push the VLAN, MPLS or PBB
+// tag onto the processing packet.
 type ActionPush struct {
-	// One of PAT_PUSH_VLAN/MPLS/PBB
+	// Type is the Push-Action type. It should be one of
+	// VLAN, MPLS or PBB.
 	Type ActionType
+
 	// The EtherType indicates the Ethertype of the new tag.
-	// It is used when pushing a new VLAN tag, new
-	// MPLS header or PBB service header.
+	//
+	// It is used when pushing a new VLAN tag, new MPLS header
+	// or PBB service header.
 	EtherType uint16
 }
 
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
 func (a ActionPush) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
 		actionhdr{a.Type, 8}, a.EtherType, pad2{},
 	})
 }
 
-// Action structure for OFPAT_POP_MPLS
+// ActionPopMPLS is an action used to extract the outer-most MPLS tag
+// or shim header from the processing packet.
 type ActionPopMPLS struct {
 	// The EtherType indicates the Ethertype of the payload.
 	EtherType uint16
 }
 
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
 func (a ActionPopMPLS) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
-		actionhdr{AT_POP_MPLS, 8}, a, pad2{},
+		actionhdr{ActionTypePopMPLS, 8}, a, pad2{},
 	})
 }
 
-// Action structure for PAT_SET_FIELD
+// ActionSetField is an action used to set the value of the packet field.
 type ActionSetField struct {
-	// Field contains a header field described
-	// using a single OXM TLV structure.
+	// Field contains a header field described using
+	// a single OXM TLV structure.
 	Field OXM
 }
 
-// WriteTo implemetes WriterTo interface.
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
 func (a ActionSetField) WriteTo(w io.Writer) (int64, error) {
 	var buf bytes.Buffer
 
@@ -239,18 +282,20 @@ func (a ActionSetField) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
-		actionhdr{AT_SET_FIELD, uint16(buf.Len() + 4)}, buf.Bytes(),
+		actionhdr{ActionTypeSetField, uint16(buf.Len() + 4)}, buf.Bytes(),
 	})
 }
 
-// Action header for PAT_EXPERIMENTER.
-// The rest of the body is experimenter-defined
+// ActionExperimenter is an experimenter action.
 type ActionExperimenter struct {
+	// The Experimenter identifies the experimental feature.
 	Experimenter uint32
 }
 
-func (a *ActionExperimenter) WriteTo(w io.Writer) (int64, error) {
+// WriteTo implement the io.WriterTo interface. It serializes the action
+// with a necessary padding.
+func (a ActionExperimenter) WriteTo(w io.Writer) (int64, error) {
 	return binary.WriteSlice(w, binary.BigEndian, []interface{}{
-		actionhdr{AT_EXPERIMENTER, 8}, a,
+		actionhdr{ActionTypeExperimenter, 8}, a,
 	})
 }

--- a/ofp.v13/group.go
+++ b/ofp.v13/group.go
@@ -19,12 +19,14 @@ type GroupType uint8
 
 const (
 	// Last usable group number
-	G_MAX Group = 0xffffff00
+	GroupMax Group = 0xffffff00
+
 	// Represents all groups for group delete commands
-	G_ALL Group = 0xfffffffc
+	GroupAll Group = 0xfffffffc
+
 	// Wildcard group used only for flow stats requests.
 	// Selects all flows regardless of group (including flows with no group)
-	G_ANY Group = 0xffffffff
+	GroupAny Group = 0xffffffff
 )
 
 type Group uint32

--- a/ofp.v13/main_test.go
+++ b/ofp.v13/main_test.go
@@ -1,0 +1,38 @@
+package ofp
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+type testValue struct {
+	w io.WriterTo
+	b []byte
+}
+
+// testMarshal validate, that each passed writer produces
+// exact sequence of bytes, as specified.
+func testMarshal(t *testing.T, tests []testValue) {
+	for _, test := range tests {
+		var buf bytes.Buffer
+		nn, err := test.w.WriteTo(&buf)
+
+		if err != nil {
+			t.Fatalf("Failed to marshal the given packet:"+
+				"%x, got error: %s", test.b, err)
+		}
+
+		if nn != int64(len(test.b)) {
+			t.Fatalf("Invalid length returned on attempt to "+
+				"marshal: `%x`: %d, expected %d",
+				test.b, nn, len(test.b))
+		}
+
+		if bytes.Compare(test.b, buf.Bytes()) != 0 {
+			t.Fatalf("The marshaled result is not equal to "+
+				"the expected one: `%x`, got instead: `%x`",
+				test.b, buf.Bytes())
+		}
+	}
+}

--- a/ofp.v13/port.go
+++ b/ofp.v13/port.go
@@ -164,35 +164,35 @@ const (
 	// Send the packet out the input port. This reserved
 	// port must be explicitly used in order to send back
 	// out of the input port.
-	P_IN_PORT PortNo = 0xfffffff8 + iota
+	PortIn PortNo = 0xfffffff8 + iota
 
 	// Submit the packet to the first flow table. This
 	// destination port can only be used in packet-out messages.
-	P_TABLE PortNo = 0xfffffff8 + iota
+	PortTable PortNo = 0xfffffff8 + iota
 
 	// Process with normal L2/L3 switching.
-	P_NORMAL PortNo = 0xfffffff8 + iota
+	PortNormal PortNo = 0xfffffff8 + iota
 
 	// All physical ports in VLAN, except input port and
 	// those blocked or link down.
-	P_FLOOD PortNo = 0xfffffff8 + iota
+	PortFlood PortNo = 0xfffffff8 + iota
 
 	// All physical ports except input port.
-	P_ALL PortNo = 0xfffffff8 + iota
+	PortAll PortNo = 0xfffffff8 + iota
 
 	// Send to controller.
-	P_CONTROLLER PortNo = 0xfffffff8 + iota
+	PortController PortNo = 0xfffffff8 + iota
 
 	// Local openflow "port".
-	P_LOCAL PortNo = 0xfffffff8 + iota
+	PortLocal PortNo = 0xfffffff8 + iota
 
 	// Wildcard port used only for flow mod (delete) and flow
 	// stats requests. Selects all flows regardless of output port
 	// (including flows with no output port).
-	P_ANY PortNo = 0xffffffff
+	PortAny PortNo = 0xffffffff
 
 	// Maximum number of physical and logical switch ports
-	P_MAX PortNo = 0xffffff00
+	PortMax PortNo = 0xffffff00
 )
 
 type PortNo uint32

--- a/ofp.v13/queue.go
+++ b/ofp.v13/queue.go
@@ -10,7 +10,7 @@ type QueueProperties uint16
 
 const (
 	//TODO: Q_ANY Queue
-	Q_ALL Queue = 0xffffffff
+	QueueAll Queue = 0xffffffff
 )
 
 type Queue uint32


### PR DESCRIPTION
This patch modifies the naming of the OFP action types to
comply with golint requirements. As well, this patch provides
the unit-tests to validate the actions serialization.