### PR TITLE
Replace io.Reader interface on io.WriterTo interface

### DIFF
--- a/header.go
+++ b/header.go
@@ -3,7 +3,7 @@ package of
 import (
 	"io"
 
-	"github.com/netrack/openflow/encoding/binary"
+	"github.com/netrack/openflow/encoding"
 )
 
 const (
@@ -85,10 +85,10 @@ func (h *Header) Len() int {
 
 // WriteTo writes the header in the write format to the given writer.
 func (h *Header) WriteTo(w io.Writer) (int64, error) {
-	return binary.Write(w, binary.BigEndian, h)
+	return encoding.WriteTo(w, *h)
 }
 
 // ReadFrom reads the header from the given reader in the wire format.
 func (h *Header) ReadFrom(r io.Reader) (int64, error) {
-	return binary.Read(r, binary.BigEndian, h)
+	return encoding.ReadFrom(r, &h.Version, &h.Type, &h.Length, &h.XID)
 }

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,35 @@
+package of
+
+import (
+	"bytes"
+	"io"
+)
+
+type readerFunc func([]byte) (int, error)
+
+func (fn readerFunc) Read(b []byte) (int, error) {
+	return fn(b)
+}
+
+func newReader(w ...io.WriterTo) io.Reader {
+	return readerFunc(func(b []byte) (int, error) {
+		var buf bytes.Buffer
+		var err error
+
+		for _, wt := range w {
+			if wt == nil {
+				continue
+			}
+
+			if _, err = wt.WriteTo(&buf); err != nil {
+				break
+			}
+		}
+
+		if err != nil {
+			return 0, err
+		}
+
+		return buf.Read(b)
+	})
+}

--- a/request.go
+++ b/request.go
@@ -48,8 +48,12 @@ type Request struct {
 
 // NewRequest returns a new Request given a type, address, and optional
 // body.
-func NewRequest(t Type, body io.Reader) (*Request, error) {
-	req := &Request{Body: body, Proto: "OFP/1.3", ProtoMajor: 1, ProtoMinor: 3}
+func NewRequest(t Type, body ...io.WriterTo) (*Request, error) {
+	req := &Request{
+		Body:       newReader(body...),
+		Proto:      "OFP/1.3",
+		ProtoMajor: 1, ProtoMinor: 3,
+	}
 
 	req.Header.Version = uint8(req.ProtoMajor + req.ProtoMinor)
 	req.Header.Type = t


### PR DESCRIPTION
This patch replaces io.Reader interface in the NewRequest function
on io.WriterTo interface in order to simplify the usage.