### PR TITLE
Port stringers and statistics

### DIFF
--- a/encoding/encodingtest/testing.go
+++ b/encoding/encodingtest/testing.go
@@ -83,7 +83,7 @@ func RunU(t *testing.T, tests []U) {
 
 		if bytes.Compare(before.Bytes(), after.Bytes()) != 0 {
 			t.Fatalf("The unmarshaled result is not equal to "+
-				"the expected one:\n`%v`,\ngot instead:\n`%v`\n%v",
+				"the expected one:\n`%x`,\ngot instead:\n`%x`\n%v",
 				before.Bytes(), after.Bytes(), test.Reader)
 		}
 	}

--- a/ofp.v13/pad.go
+++ b/ofp.v13/pad.go
@@ -19,4 +19,5 @@ var (
 	defaultPad4 pad4
 	defaultPad5 pad5
 	defaultPad6 pad6
+	defaultPad7 pad7
 )

--- a/ofp.v13/port.go
+++ b/ofp.v13/port.go
@@ -1,163 +1,133 @@
 package ofp
 
 import (
+	"fmt"
 	"io"
 	"net"
-	"strings"
 
 	"github.com/netrack/openflow/encoding"
 )
 
 const (
-	PF_10MB_HD  PortFeatures = 1 << iota
-	PF_10MB_FD  PortFeatures = 1 << iota
-	PF_100MB_HD PortFeatures = 1 << iota
-	PF_100MB_FD PortFeatures = 1 << iota
-	PF_1GB_HD   PortFeatures = 1 << iota
-	PF_1GB_FD   PortFeatures = 1 << iota
-	PF_10GB_FD  PortFeatures = 1 << iota
-	PF_40GB_FD  PortFeatures = 1 << iota
-	PF_100GB_FD PortFeatures = 1 << iota
-	PF_1TB_FD   PortFeatures = 1 << iota
-	PF_OTHER    PortFeatures = 1 << iota
+	PortFeature10MbitHalfDuplex  PortFeature = 1 << iota
+	PortFeature10MbitFullDuplex  PortFeature = 1 << iota
+	PortFeature100MbitHalfDuplex PortFeature = 1 << iota
+	PortFeature100MbitFullDuplex PortFeature = 1 << iota
+	PortFeature1GbitHalfDuplex   PortFeature = 1 << iota
+	PortFeature1GbitFullDuplex   PortFeature = 1 << iota
+	PortFeature10GbitFullDuplex  PortFeature = 1 << iota
+	PortFeature40GbitFullDuplex  PortFeature = 1 << iota
+	PortFeature100GbitFullDuplex PortFeature = 1 << iota
+	PortFeature1TbitFullDuplex   PortFeature = 1 << iota
+	PortFeatureOther             PortFeature = 1 << iota
 
-	PF_COPPER     PortFeatures = 1 << iota
-	PF_FIBER      PortFeatures = 1 << iota
-	PF_AUTONEG    PortFeatures = 1 << iota
-	PF_PAUSE      PortFeatures = 1 << iota
-	PF_PAUSE_ASYM PortFeatures = 1 << iota
+	PortFeatureCopper    PortFeature = 1 << iota
+	PortFeatureFiber     PortFeature = 1 << iota
+	PortFeatureAutoneg   PortFeature = 1 << iota
+	PortFeaturePause     PortFeature = 1 << iota
+	PortFeaturePauseAsym PortFeature = 1 << iota
 )
 
-type PortFeatures uint32
+const (
+	portFeatureSpeedMask  = 0x000007ff
+	portFeatureMediumMask = 0x0000f800
+)
 
-func (f PortFeatures) String() string {
-	// 10Mbps full-duplex copper
-	var repr string
+type PortFeature uint32
 
-	switch {
-	case f&PF_10MB_HD != 0:
-		repr = "10 Mbps half-duplex"
-	case f&PF_10MB_FD != 0:
-		repr = "10 Mbps full-duplex"
-	case f&PF_100MB_HD != 0:
-		repr = "100 Mbps half-duplex"
-	case f&PF_100MB_FD != 0:
-		repr = "100 Mbps full-duplex"
-	case f&PF_1GB_HD != 0:
-		repr = "1 Gbps half-duplex"
-	case f&PF_1GB_FD != 0:
-		repr = "1 Gbps full-duplex"
-	case f&PF_10GB_FD != 0:
-		repr = "10 Gbps full-duplex"
-	case f&PF_40GB_FD != 0:
-		repr = "40 Gbps full-duplex"
-	case f&PF_100GB_FD != 0:
-		repr = "100 Gbps full-duplex"
-	case f&PF_1TB_FD != 0:
-		repr = "1 Tbps full-duplex"
-	case f&PF_OTHER != 0:
-		repr = "other"
-	default:
-		repr = "unknown"
+var portFeaturesText = map[PortFeature]string{
+	PortFeature10MbitHalfDuplex:  "10 Mbps half-duplex",
+	PortFeature10MbitFullDuplex:  "10 Mbps full-duplex",
+	PortFeature100MbitHalfDuplex: "100 Mbps half-duplex",
+	PortFeature100MbitFullDuplex: "100 Mbps full-duplex",
+	PortFeature1GbitHalfDuplex:   "1 Gbps half-duplex",
+	PortFeature1GbitFullDuplex:   "1 Gbps full-duplex",
+	PortFeature10GbitFullDuplex:  "10 Gbps full-duplex",
+	PortFeature40GbitFullDuplex:  "40 Gbps full-duplex",
+	PortFeature100GbitFullDuplex: "100 Gbps full-duplex",
+	PortFeature1TbitFullDuplex:   "1 Tbps full-duplex",
+	PortFeatureOther:             "other",
+	PortFeatureCopper:            "copper",
+	PortFeatureFiber:             "fiber",
+	PortFeatureAutoneg:           "autoneg",
+	PortFeaturePause:             "pause",
+	PortFeaturePauseAsym:         "pause asym",
+}
+
+func (f PortFeature) String() string {
+	speed, ok := portFeaturesText[f&portFeatureSpeedMask]
+	if !ok {
+		speed = "unknown"
 	}
 
-	switch {
-	case f&PF_COPPER != 0:
-		repr += " copper"
-	case f&PF_FIBER != 0:
-		repr += " fiber"
-	case f&PF_AUTONEG != 0:
-		repr += " autoneg"
-	case f&PF_PAUSE != 0:
-		repr += " pause"
-	case f&PF_PAUSE_ASYM != 0:
-		repr += " pause asym"
-	default:
-		repr += " unknown"
+	medium, ok := portFeaturesText[f&portFeatureMediumMask]
+	if !ok {
+		medium = "unknown"
 	}
 
-	return repr
+	return fmt.Sprintf("%s %s", speed, medium)
 }
 
 const (
 	// Port is administratively down
-	PC_PORT_DOWN PortConfig = 1 << iota
+	PortConfigDown PortConfig = 1 << iota
 
 	// Drop all packets received by port
-	PC_NO_RCV PortConfig = 1 << iota
+	PortConfigNoRcv PortConfig = 1 << iota
 
 	// Drop packets forwarded to port
-	PC_NO_FWD PortConfig = 1 << iota
+	PortConfigNoFwd PortConfig = 1 << iota
 
 	// Do not send packet-in msgs for port
-	PC_NO_PACKET_IN PortConfig = 1 << iota
+	PortConfigNoPacketIn PortConfig = 1 << iota
 )
 
 type PortConfig uint32
 
+var portConfigText = map[PortConfig]string{
+	PortConfigDown:       "down",
+	PortConfigNoRcv:      "no recv",
+	PortConfigNoFwd:      "no fwd",
+	PortConfigNoPacketIn: "no packet in",
+}
+
 func (c PortConfig) String() string {
-	var repr []string
-
-	if c&PC_PORT_DOWN != 0 {
-		repr = append(repr, "DOWN")
+	if text, ok := portConfigText[c]; ok {
+		return text
 	}
 
-	if c&PC_NO_RCV != 0 {
-		repr = append(repr, "NO_RCV")
-	}
-
-	if c&PC_NO_FWD != 0 {
-		repr = append(repr, "NO_FWD")
-	}
-
-	if c&PC_NO_PACKET_IN != 0 {
-		repr = append(repr, "NO_PACKET_IN")
-	}
-
-	if len(repr) == 0 {
-		repr = append(repr, "UP")
-	}
-
-	return strings.Join(repr, ",")
+	return "up"
 }
 
 const (
 	// PS_LINK_DOWN bit indicates that the physical link is not present.
-	PS_LINK_DOWN PortState = 1 << iota
+	PortStateLinkDown PortState = 1 << iota
 
 	// PS_BLOCKED bit indicates that a switch protocol outside
 	// of OpenFlow, such as 802.1D Spanning Tree, is preventing
 	// the use of that port with OFPP_FLOOD.
-	PS_BLOCKED PortState = 1 << iota
+	PortStateBlocked PortState = 1 << iota
 
 	// PS_LIVE indicates that port available for live for Fast Failover Group
-	PS_LIVE PortState = 1 << iota
+	PortStateLive PortState = 1 << iota
 )
 
 // Current state of the physical port. These are
 // not configurable from the controller
 type PortState uint32
 
+var portStateText = map[PortState]string{
+	PortStateLinkDown: "link down",
+	PortStateBlocked:  "blocked",
+	PortStateLive:     "live",
+}
+
 func (s PortState) String() string {
-	var repr []string
-
-	if s&PS_LINK_DOWN != 0 {
-		repr = append(repr, "LINK_DOWN")
+	if text, ok := portStateText[s]; ok {
+		return text
 	}
 
-	if s&PS_BLOCKED != 0 {
-		repr = append(repr, "BLOCKED")
-	}
-
-	if s&PS_LIVE != 0 {
-		repr = append(repr, "LIVE")
-	}
-
-	if len(repr) == 0 {
-		repr = append(repr, "LINK_UP")
-	}
-
-	return strings.Join(repr, ",")
+	return "link up"
 }
 
 const (
@@ -197,7 +167,7 @@ const (
 
 type PortNo uint32
 
-const MAX_PORT_NAME_LEN = 16
+const portNameLen = 16
 
 // The port description request MP_PORT_DESCRIPTION enables the
 // controller to get a description of all the ports in the system
@@ -206,19 +176,19 @@ const MAX_PORT_NAME_LEN = 16
 type Port struct {
 	PortNo PortNo
 	HWAddr net.HardwareAddr
-	Name   []byte
+	Name   string
 
 	Config PortConfig
 	State  PortState
 
 	// Current features
-	Curr PortFeatures
+	Curr PortFeature
 	// Features being advertised by the port
-	Advertised PortFeatures
+	Advertised PortFeature
 	// Features supported by the port
-	Supported PortFeatures
+	Supported PortFeature
 	// Features advertised by peer
-	Peer PortFeatures
+	Peer PortFeature
 
 	// Current port bitrate in kbps
 	CurrSpeed uint32
@@ -226,16 +196,37 @@ type Port struct {
 	MaxSpeed uint32
 }
 
+func (p *Port) WriteTo(w io.Writer) (int64, error) {
+	name := make([]byte, portNameLen)
+	copy(name, []byte(p.Name))
+
+	return encoding.WriteTo(w,
+		p.PortNo,
+		pad4{},
+		p.HWAddr,
+		pad2{},
+		name,
+		p.Config,
+		p.State,
+		p.Curr,
+		p.Advertised,
+		p.Supported,
+		p.Peer,
+		p.CurrSpeed,
+		p.MaxSpeed,
+	)
+}
+
 func (p *Port) ReadFrom(r io.Reader) (int64, error) {
 	p.HWAddr = make(net.HardwareAddr, 6)
-	p.Name = make([]byte, MAX_PORT_NAME_LEN)
+	var name [portNameLen]byte
 
-	return encoding.ReadFrom(r,
+	n, err := encoding.ReadFrom(r,
 		&p.PortNo,
-		&pad4{},
+		&defaultPad4,
 		&p.HWAddr,
-		&pad2{},
-		&p.Name,
+		&defaultPad2,
+		&name,
 		&p.Config,
 		&p.State,
 		&p.Curr,
@@ -245,6 +236,9 @@ func (p *Port) ReadFrom(r io.Reader) (int64, error) {
 		&p.CurrSpeed,
 		&p.MaxSpeed,
 	)
+
+	p.Name = string(name[:])
+	return n, err
 }
 
 type Ports []Port
@@ -270,42 +264,72 @@ func (p *Ports) ReadFrom(r io.Reader) (n int64, err error) {
 
 type PortMod struct {
 	PortNo    PortNo
-	_         pad4
 	HWAddr    net.HardwareAddr
-	_         pad2
 	Config    PortConfig
 	Mask      PortConfig
-	Advertise PortFeatures
-	_         pad4
+	Advertise PortFeature
+}
+
+func (p *PortMod) WriteTo(w io.Writer) (int64, error) {
+	return encoding.WriteTo(w,
+		p.PortNo, pad4{},
+		p.HWAddr, pad2{},
+		p.Config,
+		p.Mask,
+		p.Advertise, pad4{},
+	)
+}
+
+func (p *PortMod) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r,
+		&p.PortNo, &defaultPad4,
+		&p.HWAddr, &defaultPad2,
+		&p.Config,
+		&p.Mask,
+		&p.Advertise, &defaultPad4,
+	)
 }
 
 const (
 	// The port was added
-	PR_ADD PortReason = iota
+	PortReasonAdd PortReason = iota
 
 	// The port was removed
-	PR_DELETE
+	PortReasonDelete
 
 	// Some attribute of the port has changed
-	PR_MODIFY
+	PortReasonModify
 )
 
 type PortReason uint8
 
 type PortStatus struct {
 	Reason PortReason
-	_      pad7
-	Desc   Port
+	Port   Port
+}
+
+func (p *PortStatus) WriteTo(w io.Writer) (int64, error) {
+	return encoding.WriteTo(w, p.Reason, pad7{}, &p.Port)
+}
+
+func (p *PortStatus) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &p.Reason, &defaultPad7, &p.Port)
 }
 
 type PortStatsRequest struct {
 	PortNo PortNo
-	_      pad4
+}
+
+func (p *PortStatsRequest) WriteTo(w io.Writer) (int64, error) {
+	return encoding.WriteTo(w, p.PortNo, pad4{})
+}
+
+func (p *PortStatsRequest) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &p.PortNo, &defaultPad4)
 }
 
 type PortStats struct {
 	PortNo       PortNo
-	_            pad4
 	RxPackets    uint64
 	TxPackets    uint64
 	RxBytes      uint64
@@ -320,4 +344,46 @@ type PortStats struct {
 	Collisions   uint64
 	DurationSec  uint32
 	DurationNSec uint32
+}
+
+func (p *PortStats) WriteTo(w io.Writer) (int64, error) {
+	return encoding.WriteTo(w,
+		p.PortNo,
+		pad4{},
+		p.RxPackets,
+		p.TxPackets,
+		p.RxBytes,
+		p.TxBytes,
+		p.RxDropped,
+		p.TxDropped,
+		p.RxErrors,
+		p.TxErrors,
+		p.RxFrameErr,
+		p.RxOverErr,
+		p.RxCrcErr,
+		p.Collisions,
+		p.DurationSec,
+		p.DurationNSec,
+	)
+}
+
+func (p *PortStats) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r,
+		&p.PortNo,
+		&defaultPad4,
+		&p.RxPackets,
+		&p.TxPackets,
+		&p.RxBytes,
+		&p.TxBytes,
+		&p.RxDropped,
+		&p.TxDropped,
+		&p.RxErrors,
+		&p.TxErrors,
+		&p.RxFrameErr,
+		&p.RxOverErr,
+		&p.RxCrcErr,
+		&p.Collisions,
+		&p.DurationSec,
+		&p.DurationNSec,
+	)
 }

--- a/ofp.v13/port_test.go
+++ b/ofp.v13/port_test.go
@@ -1,0 +1,232 @@
+package ofp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/netrack/openflow/encoding/encodingtest"
+)
+
+var hwaddr, _ = net.ParseMAC("0123.4567.89ab")
+
+func TestPortFeatureString(t *testing.T) {
+	pf := []PortFeature{
+		PortFeature1GbitHalfDuplex | PortFeatureCopper,
+		PortFeatureOther | PortFeaturePauseAsym,
+		PortFeature10MbitHalfDuplex | PortFeatureFiber,
+		PortFeature40GbitFullDuplex | PortFeaturePause,
+		PortFeature1TbitFullDuplex | PortFeatureFiber,
+	}
+
+	features := map[PortFeature]string{
+		pf[0]: "1 Gbps half-duplex copper",
+		pf[1]: "other pause asym",
+		pf[2]: "10 Mbps half-duplex fiber",
+		pf[3]: "40 Gbps full-duplex pause",
+		pf[4]: "1 Tbps full-duplex fiber",
+	}
+
+	for feature, text := range features {
+		if feature.String() != text {
+			t.Errorf("Invalid port feature, expected:\n"+
+				"`%s` got:\n`%s`", text, feature.String())
+		}
+	}
+}
+
+func TestPortConfigString(t *testing.T) {
+	pc := map[PortConfig]string{
+		PortConfigDown: "down",
+		PortConfig(0):  "up",
+	}
+
+	for config, text := range pc {
+		if config.String() != text {
+			t.Errorf("Invalid port config, expected:\n, "+
+				"`%s` got:\n`%s`", text, config.String())
+		}
+	}
+}
+
+func TestPortStateString(t *testing.T) {
+	ps := map[PortState]string{
+		PortStateLinkDown: "link down",
+		PortStateLive:     "live",
+		PortState(0):      "link up",
+	}
+
+	for state, text := range ps {
+		if state.String() != text {
+			t.Errorf("Invalid port state, expected:\n"+
+				"`%s` got:\n`%s`", text, state.String())
+		}
+	}
+}
+
+func TestPort(t *testing.T) {
+	features := PortFeature1GbitFullDuplex | PortFeatureFiber
+	peer := PortFeature10GbitFullDuplex | PortFeatureCopper
+
+	name := make([]byte, portNameLen)
+	copy(name, "sw1-eth0")
+
+	tests := []encodingtest.MU{
+		{&Port{
+			PortNo:     PortNormal,
+			HWAddr:     hwaddr,
+			Name:       string(name),
+			Config:     PortConfigDown,
+			State:      PortStateLinkDown,
+			Curr:       features,
+			Advertised: features,
+			Supported:  features,
+			Peer:       peer,
+			CurrSpeed:  42,
+			MaxSpeed:   43,
+		}, []byte{
+			0xff, 0xff, 0xff, 0xfa, // Port number.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x01, 0x23, 0x45, 0x67, 0x89, 0xab, // Hardware address.
+			0x00, 0x00, // 2-byte padding.
+			0x73, 0x77, 0x31, 0x2d, 0x65, 0x74, 0x68, 0x30,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Name.
+			0x00, 0x00, 0x00, 0x01, // Port configuration.
+			0x00, 0x00, 0x00, 0x01, // Port state.
+			0x00, 0x00, 0x10, 0x20, // Current port features.
+			0x00, 0x00, 0x10, 0x20, // Advertised port features.
+			0x00, 0x00, 0x10, 0x20, // Supported port features.
+			0x00, 0x00, 0x08, 0x40, // Peer port features.
+			0x00, 0x00, 0x00, 0x2a, // Current speed.
+			0x00, 0x00, 0x00, 0x2b, // Maximum speed.
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestPortMod(t *testing.T) {
+	features := PortFeature10GbitFullDuplex | PortFeatureAutoneg
+
+	tests := []encodingtest.MU{
+		{&PortMod{
+			PortNo:    PortFlood,
+			HWAddr:    hwaddr,
+			Config:    PortConfigNoFwd,
+			Mask:      PortConfig(0),
+			Advertise: features,
+		}, []byte{
+			0xff, 0xff, 0xff, 0xfb, // Port number.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x01, 0x23, 0x45, 0x67, 0x89, 0xab, // Hardware address.
+			0x00, 0x00, // 2-byte padding.
+			0x00, 0x00, 0x00, 0x04, // Port configuration.
+			0x00, 0x00, 0x00, 0x00, // Port configuration mask.
+			0x00, 0x00, 0x20, 0x40, // Supported port features.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestPortStatus(t *testing.T) {
+	features := PortFeature40GbitFullDuplex | PortFeatureFiber
+	peer := PortFeature10MbitHalfDuplex | PortFeatureCopper
+
+	name := make([]byte, portNameLen)
+	copy(name, "sw1-eth1")
+
+	tests := []encodingtest.MU{
+		{&PortStatus{
+			Reason: PortReasonAdd,
+			Port: Port{
+				PortNo:     PortFlood,
+				HWAddr:     hwaddr,
+				Name:       string(name),
+				Config:     PortConfigDown,
+				State:      PortStateLinkDown,
+				Curr:       features,
+				Advertised: features,
+				Supported:  features,
+				Peer:       peer,
+				CurrSpeed:  2047,
+				MaxSpeed:   65535,
+			},
+		}, []byte{
+			0x00,                                     // Port status reason.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 7-byte padding.
+
+			// Port.
+			0xff, 0xff, 0xff, 0xfb, // Port number.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x01, 0x23, 0x45, 0x67, 0x89, 0xab, // Hardware address.
+			0x00, 0x00, // 2-byte padding.
+			0x73, 0x77, 0x31, 0x2d, 0x65, 0x74, 0x68, 0x31,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Name.
+			0x00, 0x00, 0x00, 0x01, // Port configuration.
+			0x00, 0x00, 0x00, 0x01, // Port state.
+			0x00, 0x00, 0x10, 0x80, // Current port features.
+			0x00, 0x00, 0x10, 0x80, // Advertised port features.
+			0x00, 0x00, 0x10, 0x80, // Supported port features.
+			0x00, 0x00, 0x08, 0x01, // Peer port features.
+			0x00, 0x00, 0x07, 0xff, // Current speed.
+			0x00, 0x00, 0xff, 0xff, // Maximum speed.
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestPortStatsRequest(t *testing.T) {
+	tests := []encodingtest.MU{
+		{&PortStatsRequest{
+			PortNo: PortNo(2),
+		}, []byte{
+			0x00, 0x00, 0x00, 0x02, // Port number.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestPortStats(t *testing.T) {
+	tests := []encodingtest.MU{
+		{&PortStats{
+			PortNo:       PortNo(3),
+			RxPackets:    6773009508081008653,
+			TxPackets:    4449515516159517871,
+			RxBytes:      5376522659808774614,
+			TxBytes:      13087997567122713610,
+			RxDropped:    14817532963293049516,
+			TxDropped:    1483028468767136997,
+			RxErrors:     8919350792100524585,
+			TxErrors:     8235451563360597435,
+			RxFrameErr:   12151775103618862338,
+			RxOverErr:    8345656100423014979,
+			RxCrcErr:     7312308705513999709,
+			Collisions:   7394863223143382373,
+			DurationSec:  684498643,
+			DurationNSec: 2789499113,
+		}, []byte{
+			0x00, 0x00, 0x00, 0x03, // Port number.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x5d, 0xfe, 0x90, 0x43, 0x3d, 0x83, 0x00, 0x0d, // Rx packets.
+			0x3d, 0xbf, 0xda, 0xc9, 0x93, 0x46, 0xe4, 0xaf, // Tx packets.
+			0x4a, 0x9d, 0x3e, 0xdf, 0x80, 0xbd, 0x89, 0xd6, // Rx bytes.
+			0xb5, 0xa1, 0xe8, 0x71, 0xb1, 0x86, 0xac, 0x0a, // Tx bytes.
+			0xcd, 0xa2, 0x73, 0xb9, 0x34, 0xb9, 0x32, 0xac, // Rx dropped.
+			0x14, 0x94, 0xc6, 0x88, 0xf0, 0xa8, 0x1c, 0xe5, // Tx dropped.
+			0x7b, 0xc7, 0xe6, 0x49, 0xe6, 0x40, 0x32, 0x29, // Rx errors.
+			0x72, 0x4a, 0x33, 0x90, 0x47, 0x0b, 0x35, 0xbb, // Tx errors.
+			0xa8, 0xa3, 0xc7, 0x12, 0xe9, 0xa3, 0x4d, 0x02, // Rx frame errors.
+			0x73, 0xd1, 0xba, 0x01, 0x93, 0x49, 0x1a, 0x43, // Rx over errors.
+			0x65, 0x7a, 0x8a, 0x06, 0x80, 0x28, 0x8d, 0x5d, // Rx CRC errors.
+			0x66, 0x9f, 0xd4, 0xeb, 0xfa, 0x0f, 0xbd, 0x65, // Collisions.
+			0x28, 0xcc, 0x9e, 0xd3, // Duration seconds.
+			0xa6, 0x44, 0x60, 0xe9, // Duration nanoseconds.
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}


### PR DESCRIPTION
This patch provides implementation of the marshaling/unmarshaling
methods for port statistics, port statistics requet, port status
and port modification OpenFlow messages.

Also, it defines the stringer methods for port features, status
and configuration.