### PR TITLE
Queue messages marshaling/unmarshaling

### DIFF
--- a/ofp.v13/queue.go
+++ b/ofp.v13/queue.go
@@ -1,12 +1,27 @@
 package ofp
 
-const (
-	QT_MIN_RATE     QueueProperties = iota
-	QT_MAX_RATE     QueueProperties = iota
-	QT_EXPERIMENTER QueueProperties = 0xffff
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/netrack/openflow/encoding"
 )
 
-type QueueProperties uint16
+const (
+	QueuePropTypeMinRate      QueuePropType = 1 + iota
+	QueuePropTypeMaxRate      QueuePropType = 1 + iota
+	QueuePropTypeExperimenter QueuePropType = 0xffff
+)
+
+type QueuePropType uint16
+
+var queuePropTypeMap = map[QueuePropType]encoding.ReaderMaker{
+	QueuePropTypeMinRate:      encoding.ReaderMakerOf(QueuePropMinRate{}),
+	QueuePropTypeMaxRate:      encoding.ReaderMakerOf(QueuePropMaxRate{}),
+	QueuePropTypeExperimenter: encoding.ReaderMakerOf(QueuePropExperimenter{}),
+}
 
 const (
 	//TODO: Q_ANY Queue
@@ -15,47 +30,164 @@ const (
 
 type Queue uint32
 
-type PacketQueue struct {
-	QueueID    Queue
-	Port       PortNo
-	Length     uint16
-	_          pad6
-	Properties []QueuePropHeader
+type QueueProp interface {
+	encoding.ReadWriter
+
+	Type() QueuePropType
 }
 
-type QueuePropHeader struct {
-	Property QueueProperties
-	Length   uint16
-	_        pad3
+type QueueProps []QueueProp
+
+func (q QueueProps) WriteTo(w io.Writer) (int64, error) {
+	var buf bytes.Buffer
+
+	for _, prop := range q {
+		_, err := prop.WriteTo(&buf)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return encoding.WriteTo(w, buf.Bytes())
+}
+
+func (q QueueProps) ReadFrom(r io.Reader) (int64, error) {
+	var queueType QueuePropType
+
+	rm := func() (io.ReaderFrom, error) {
+		if rm, ok := queuePropTypeMap[queueType]; ok {
+			rd, err := rm.MakeReader()
+			q = append(q, rd.(QueueProp))
+			return rd, err
+		}
+
+		format := "ofp: unknown queue property type: '%x'"
+		return nil, fmt.Errorf(format, queueType)
+	}
+
+	return encoding.ScanFrom(r, &queueType,
+		encoding.ReaderMakerFunc(rm))
+}
+
+const packetQueueLen = 16
+
+type PacketQueue struct {
+	Queue      Queue
+	Port       PortNo
+	Properties QueueProps
+}
+
+func (q *PacketQueue) WriteTo(w io.Writer) (int64, error) {
+	var buf bytes.Buffer
+	_, err := q.Properties.WriteTo(&buf)
+	if err != nil {
+		return 0, err
+	}
+
+	return encoding.WriteTo(w, q.Queue, q.Port,
+		uint16(buf.Len()+packetQueueLen), pad6{}, buf.Bytes())
+}
+
+func (q *PacketQueue) ReadFrom(r io.Reader) (int64, error) {
+	var length uint16
+	n, err := encoding.ReadFrom(r, &q.Queue, &q.Port,
+		&length, &defaultPad6)
+
+	if err != nil {
+		return n, err
+	}
+
+	limrd := io.LimitReader(r, int64(length-packetQueueLen))
+	nn, err := q.Properties.ReadFrom(limrd)
+	return n + nn, err
+}
+
+const queuePropLen = 16
+
+type queuePropHdr struct {
+	Type QueuePropType
+	Len  uint16
 }
 
 type QueuePropMinRate struct {
-	PropHeader QueuePropHeader
-	Rate       uint16
-	_          pad6
+	Rate uint16
+}
+
+func (q *QueuePropMinRate) Type() QueuePropType {
+	return QueuePropTypeMinRate
+}
+
+func (q *QueuePropMinRate) WriteTo(w io.Writer) (int64, error) {
+	header := queuePropHdr{q.Type(), queuePropLen}
+	return encoding.WriteTo(w, header, pad4{}, q.Rate, pad6{})
+}
+
+func (q *QueuePropMinRate) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &defaultPad8, &q.Rate, &defaultPad6)
 }
 
 type QueuePropMaxRate struct {
-	PropHeader QueuePropHeader
-	Rate       uint16
-	_          pad6
+	Rate uint16
+}
+
+func (q *QueuePropMaxRate) Type() QueuePropType {
+	return QueuePropTypeMaxRate
+}
+
+func (q *QueuePropMaxRate) WriteTo(w io.Writer) (int64, error) {
+	header := queuePropHdr{q.Type(), queuePropLen}
+	return encoding.WriteTo(w, header, pad4{}, q.Rate, pad6{})
+}
+
+func (q *QueuePropMaxRate) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &defaultPad8, &q.Rate, &defaultPad6)
 }
 
 type QueuePropExperimenter struct {
-	PropHeader   QueuePropHeader
 	Experimenter uint32
-	_            pad4
 	Data         []byte
 }
 
-type QueueStatsRequest struct {
-	PornNo  PortNo
-	QueueID Queue
+func (q *QueuePropExperimenter) Type() QueuePropType {
+	return QueuePropTypeExperimenter
 }
 
-type QueueStatus struct {
-	PortNo       PortNo
-	QueueID      Queue
+func (q *QueuePropExperimenter) WriteTo(w io.Writer) (int64, error) {
+	header := queuePropHdr{q.Type(), queuePropLen + uint16(len(q.Data))}
+	return encoding.WriteTo(w, header, pad4{},
+		q.Experimenter, &pad4{}, q.Data)
+}
+
+func (q *QueuePropExperimenter) ReadFrom(r io.Reader) (int64, error) {
+	var header queuePropHdr
+	n, err := encoding.ReadFrom(r, &header, &defaultPad4,
+		&q.Experimenter, &defaultPad4)
+
+	if err != nil {
+		return n, err
+	}
+
+	limrd := io.LimitReader(r, int64(header.Len-queuePropLen))
+	q.Data, err = ioutil.ReadAll(limrd)
+	return n + int64(len(q.Data)), err
+}
+
+type QueueStatsRequest struct {
+	Port  PortNo
+	Queue Queue
+}
+
+func (q *QueueStatsRequest) WriteTo(w io.Writer) (int64, error) {
+	return encoding.WriteTo(w, q.Port, q.Queue)
+}
+
+func (q *QueueStatsRequest) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &q.Port, &q.Queue)
+}
+
+type QueueStats struct {
+	Port         PortNo
+	Queue        Queue
 	TxBytes      uint64
 	TxPackets    uint64
 	TxErrors     uint64
@@ -63,13 +195,69 @@ type QueueStatus struct {
 	DurationNSec uint32
 }
 
+func (q *QueueStats) WriteTo(w io.Writer) (int64, error) {
+	return encoding.WriteTo(w, *q)
+}
+
+func (q *QueueStats) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &q.Port, &q.Queue, &q.TxBytes,
+		&q.TxPackets, &q.TxErrors, &q.DurationSec, &q.DurationNSec)
+}
+
 type QueueGetConfigRequest struct {
 	Port PortNo
-	_    pad4
+}
+
+func (q *QueueGetConfigRequest) WriteTo(w io.Writer) (int64, error) {
+	return encoding.WriteTo(w, q.Port, pad4{})
+}
+
+func (q *QueueGetConfigRequest) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &q.Port, &defaultPad4)
 }
 
 type QueueGetConfigReply struct {
 	Port   PortNo
-	_      pad4
 	Queues []PacketQueue
+}
+
+func (q *QueueGetConfigReply) WriteTo(w io.Writer) (int64, error) {
+	var buf bytes.Buffer
+	for _, queue := range q.Queues {
+		_, err := queue.WriteTo(&buf)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return encoding.WriteTo(w, q.Port, pad4{}, buf.Bytes())
+}
+
+func (q *QueueGetConfigReply) ReadFrom(r io.Reader) (int64, error) {
+	n, err := encoding.ReadFrom(r, &q.Port, &defaultPad4)
+	if err != nil {
+		return n, err
+	}
+
+	// The passed reader should be limited to the whole
+	// OpenFlow message, thus return EOF error when the
+	// messages ends. Otherwise this implementation will
+	// read the packet queues indefinitely.
+	var queues []PacketQueue
+	for {
+		var queue PacketQueue
+		nn, err := queue.ReadFrom(r)
+		n += nn
+
+		if err != nil {
+			return n, encoding.SkipEOF(err)
+		}
+
+		queues = append(queues, queue)
+	}
+
+	// Assign the list of queues back to the reply to
+	// make the unmarshaling reproducable.
+	q.Queues = queues
+	return n, nil
 }

--- a/ofp.v13/queue_test.go
+++ b/ofp.v13/queue_test.go
@@ -1,0 +1,178 @@
+package ofp
+
+import (
+	"encoding/gob"
+	"testing"
+
+	"github.com/netrack/openflow/encoding/encodingtest"
+)
+
+func TestPacketQueue(t *testing.T) {
+	props := QueueProps{
+		&QueuePropMinRate{42},
+		&QueuePropMaxRate{43},
+	}
+
+	tests := []encodingtest.MU{
+		{&PacketQueue{
+			Queue:      QueueAll,
+			Port:       PortNormal,
+			Properties: props,
+		}, []byte{
+			0xff, 0xff, 0xff, 0xff, // Queue.
+			0xff, 0xff, 0xff, 0xfa, // Port number.
+			0x00, 0x30, // Length.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 6-byte padding.
+
+			// Properties
+			0x00, 0x01, // Queue property min rate.
+			0x00, 0x10, // Queue property length.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x00, 0x2a, // Rate.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 6-byte padding.
+
+			0x00, 0x02, // Queue property max rate.
+			0x00, 0x10, // Queue propertu length.
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x2b, // Rate.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}},
+	}
+
+	gob.Register(QueuePropMinRate{})
+	gob.Register(QueuePropMaxRate{})
+	encodingtest.RunMU(t, tests)
+}
+
+func TestQueuePropExperimenter(t *testing.T) {
+	data := []byte{0x00, 0x01, 0x02, 0x03}
+
+	tests := []encodingtest.MU{
+		{&QueuePropExperimenter{
+			Experimenter: 359,
+			Data:         data,
+		}, append([]byte{
+			0xff, 0xff, // Queue property type.
+			0x00, 0x14, // Queue property length.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x00, 0x00, 0x01, 0x67, // Experimenter.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+		}, data...)},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestQueueStastsRequest(t *testing.T) {
+	tests := []encodingtest.MU{
+		{&QueueStatsRequest{
+			Port:  PortNo(1),
+			Queue: Queue(2),
+		}, []byte{
+			0x00, 0x00, 0x00, 0x01, // Port number.
+			0x00, 0x00, 0x00, 0x02, // Queue number.
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestQueueStats(t *testing.T) {
+	tests := []encodingtest.MU{
+		{&QueueStats{
+			Port:         PortNo(42),
+			Queue:        Queue(9),
+			TxBytes:      5631918746835501714,
+			TxPackets:    13419917410144254707,
+			TxErrors:     9021256935579401134,
+			DurationSec:  3332165368,
+			DurationNSec: 3773668775,
+		}, []byte{
+			0x00, 0x00, 0x00, 0x2a, // Port number.
+			0x00, 0x00, 0x00, 0x09, // Queue.
+			0x4e, 0x28, 0x98, 0x42, 0xd4, 0xfe, 0x42, 0x92, // Tx bytes.
+			0xba, 0x3d, 0x1f, 0xc8, 0x62, 0xba, 0x7a, 0xf3, // Tx packets.
+			0x7d, 0x31, 0xf1, 0x62, 0xe0, 0xbd, 0x3b, 0xae, // Tx errors.
+			0xc6, 0x9c, 0xce, 0xf8, // Duration seconds.
+			0xe0, 0xed, 0x9d, 0xa7, // Duration nano seconds.
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestQueueGetConfigRequest(t *testing.T) {
+	tests := []encodingtest.MU{
+		{&QueueGetConfigRequest{PortNo(42)}, []byte{
+			0x00, 0x00, 0x00, 0x2a, // Port number.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestQueueGetConfigReply(t *testing.T) {
+	props1 := QueueProps{
+		&QueuePropMinRate{1},
+		&QueuePropMaxRate{2},
+	}
+
+	props2 := QueueProps{
+		&QueuePropMinRate{3},
+		&QueuePropMaxRate{4},
+	}
+
+	queues := []PacketQueue{
+		{Queue(1), PortNo(4), props1},
+		{Queue(2), PortNo(4), props2},
+	}
+
+	tests := []encodingtest.MU{
+		{&QueueGetConfigReply{
+			Port:   PortNo(43),
+			Queues: queues,
+		}, []byte{
+			0x00, 0x00, 0x00, 0x2b, // Port number.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+
+			// Queue #1.
+			0x00, 0x00, 0x00, 0x01, // Queue number.
+			0x00, 0x00, 0x00, 0x04, // Port number.
+			0x00, 0x30, // Length.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 6-byte padding.
+			// Property #1.
+			0x00, 0x01, // Queue property min rate.
+			0x00, 0x10, // Queue property length.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x00, 0x01, // Rate.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 6-byte padding.
+			// Property #2.
+			0x00, 0x02, // Queue property max rate.
+			0x00, 0x10, // Queue propertu length.
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x02, // Rate.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+			// Queue #2.
+			0x00, 0x00, 0x00, 0x02, // Queue number.
+			0x00, 0x00, 0x00, 0x04, // Port number.
+			0x00, 0x30, // Length.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 6-byte padding.
+			// Property #1.
+			0x00, 0x01, // Queue property min rate.
+			0x00, 0x10, // Queue property length.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x00, 0x03, // Rate.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 6-byte padding.
+			// Property #2.
+			0x00, 0x02, // Queue property max rate.
+			0x00, 0x10, // Queue propertu length.
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x04, // Rate.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}


### PR DESCRIPTION
This patch provides implementation of the marshaling and unmarshaling
of the OpenFlow queue messages (statistics, configuration as well as
tests for it.