### PR TITLE
Group bucket marshaling and unmarshaling

### DIFF
--- a/ofp.v13/group.go
+++ b/ofp.v13/group.go
@@ -1,18 +1,24 @@
 package ofp
 
-const (
-	GC_ADD GroupModCommand = iota
-	GC_MODIFY
-	GC_DELETE
+import (
+	"io"
+
+	"github.com/netrack/openflow/encoding"
 )
 
-type GroupModCommand uint16
+const (
+	GroupCommandAdd GroupCommand = iota
+	GroupCommandModify
+	GroupCommandDelete
+)
+
+type GroupCommand uint16
 
 const (
-	GT_ALL GroupType = iota
-	GT_SELECT
-	GT_INDIRECT
-	GT_FF
+	GroupTypeAll GroupType = iota
+	GroupTypeSelect
+	GroupTypeIndirect
+	GroupTypeFastFailover
 )
 
 type GroupType uint8
@@ -32,20 +38,51 @@ const (
 type Group uint32
 
 type GroupMod struct {
-	Command GroupModCommand
+	Command GroupCommand
 	Type    GroupType
 	_       uint8
 	GroupID uint32
 	Buckets []Bucket
 }
 
+const bucketLen = 16
+
 type Bucket struct {
-	Length     uint16
 	Weight     uint16
-	WatchPort  uint32
-	WatchGroup uint32
-	_          pad4
-	Actions    []interface{}
+	WatchPort  PortNo
+	WatchGroup Group
+	Actions    Actions
+}
+
+func (b *Bucket) WriteTo(w io.Writer) (int64, error) {
+	// Serialize the list of actions first, to set the
+	// valid length into the bucket header.
+	actions, err := b.Actions.bytes()
+	if err != nil {
+		return 0, err
+	}
+
+	// The length of the bucket header consist of the
+	// header length itself and the length of actions.
+	return encoding.WriteTo(w, uint16(bucketLen+len(actions)),
+		b.Weight, b.WatchPort, b.WatchGroup, pad4{}, actions)
+}
+
+func (b *Bucket) ReadFrom(r io.Reader) (int64, error) {
+	// Read the header of the bucket to limit the count
+	// of bytes used to unmarshal the list of actions.
+	var length uint16
+	n, err := encoding.ReadFrom(r, &length, &b.Weight,
+		&b.WatchPort, &b.WatchGroup, &defaultPad4)
+	if err != nil {
+		return n, err
+	}
+
+	// Created a limited reader to not read more bytes
+	// that it is allocated for the list of actions.
+	limrd := io.LimitReader(r, int64(length-bucketLen))
+	nn, err := b.Actions.ReadFrom(limrd)
+	return n + nn, err
 }
 
 type GroupStatsRequest struct {
@@ -70,6 +107,14 @@ type BucketCounter struct {
 	ByteCount   uint64
 }
 
+func (b *BucketCounter) WriteTo(w io.Writer) (int64, error) {
+	return encoding.WriteTo(w, b.PacketCount, b.ByteCount)
+}
+
+func (b *BucketCounter) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &b.PacketCount, &b.ByteCount)
+}
+
 type GroupDescStats struct {
 	Length  uint16
 	Type    GroupType
@@ -79,17 +124,17 @@ type GroupDescStats struct {
 }
 
 const (
-	OFPGFC_SELECT_WEIGHT   GroupCapabilities = 1 << iota
-	OFPGFC_SELECT_LIVENESS GroupCapabilities = 1 << iota
-	OFPGFC_CHAINING        GroupCapabilities = 1 << iota
-	OFPGFC_CHAINING_CHECKS GroupCapabilities = 1 << iota
+	GroupCapabilitySelectWeight   GroupCapability = 1 << iota
+	GroupCapabilitySelectLiveness GroupCapability = 1 << iota
+	GroupCapabilityChaining       GroupCapability = 1 << iota
+	GroupCapabilityChainingChecks GroupCapability = 1 << iota
 )
 
-type GroupCapabilities uint32
+type GroupCapability uint32
 
 type GroupFeatures struct {
 	Types        []GroupType
-	Capabilities GroupCapabilities
+	Capabilities GroupCapability
 	MaxGroups    []Group
 	Actions      []ActionType
 }

--- a/ofp.v13/group_test.go
+++ b/ofp.v13/group_test.go
@@ -1,0 +1,66 @@
+package ofp
+
+import (
+	"encoding/gob"
+	"testing"
+
+	"github.com/netrack/openflow/encoding/encodingtest"
+)
+
+func TestBucket(t *testing.T) {
+	actions := Actions{
+		&ActionCopyTTLIn{},
+		&ActionOutput{Port: PortNo(3), MaxLen: 65535},
+	}
+
+	tests := []encodingtest.MU{
+		{&Bucket{
+			Weight:     42,
+			WatchPort:  PortNo(5),
+			WatchGroup: Group(7),
+			Actions:    actions,
+		}, []byte{
+			0x00, 0x28, // Length.
+			0x00, 0x2a, // Wight.
+			0x00, 0x00, 0x00, 0x05, // Watch port.
+			0x00, 0x00, 0x00, 0x07, // Watch group.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+
+			// Actions.
+			0x00, 0x0c, // Copy TTL in.
+			0x00, 0x08, // Action length.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+
+			0x00, 0x00, // Output.
+			0x00, 0x10, // Action length.
+			0x00, 0x00, 0x00, 0x03, // Port number.
+			0xff, 0xff, // Maximum length.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 6-byte padding
+		}},
+	}
+
+	gob.Register(ActionCopyTTLIn{})
+	gob.Register(ActionOutput{})
+	encodingtest.RunMU(t, tests)
+}
+
+func TestBucketCounter(t *testing.T) {
+	tests := []encodingtest.MU{
+		{&BucketCounter{
+			PacketCount: 10838451347809794865,
+			ByteCount:   9634678394999596076,
+		}, []byte{
+			0x96, 0x69, 0xea, 0x13, 0x85, 0x8e, 0x7b, 0x31,
+			0x85, 0xb5, 0x40, 0xf4, 0x1b, 0x14, 0xe4, 0x2c,
+		}},
+		{&BucketCounter{
+			PacketCount: 5523660708591555761,
+			ByteCount:   14713084686717327527,
+		}, []byte{
+			0x4c, 0xa7, 0xfc, 0x26, 0x1b, 0x61, 0xd4, 0xb1,
+			0xcc, 0x2f, 0x60, 0x91, 0xbe, 0x06, 0x98, 0xa7,
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}


### PR DESCRIPTION
This patch provides implementation of the group bucket and group
bucket counter marshaling and unmarshaling from the wire format.
Also, it contains the respective tests for theses two types.