### PR TITLE
Group modification message marshaling

### DIFF
--- a/ofp.v13/group_test.go
+++ b/ofp.v13/group_test.go
@@ -44,6 +44,56 @@ func TestBucket(t *testing.T) {
 	encodingtest.RunMU(t, tests)
 }
 
+func TestGroupMod(t *testing.T) {
+	actions1 := Actions{&ActionCopyTTLIn{}}
+	actions2 := Actions{&ActionCopyTTLOut{}}
+
+	buckets := []Bucket{
+		{10, PortNo(2), Group(5), actions1},
+		{20, PortNo(3), Group(6), actions2},
+	}
+
+	tests := []encodingtest.MU{
+		{&GroupMod{
+			Command: GroupCommandModify,
+			Type:    GroupTypeIndirect,
+			Group:   Group(3),
+			Buckets: buckets,
+		}, []byte{
+			0x00, 0x01, // Group command.
+			0x02,                   // Group type.
+			0x00,                   // 1-byte padding.
+			0x00, 0x00, 0x00, 0x03, // Group identifier.
+
+			// Buckets.
+			0x00, 0x18, // Length.
+			0x00, 0x0a, // Wight.
+			0x00, 0x00, 0x00, 0x02, // Watch port.
+			0x00, 0x00, 0x00, 0x05, // Watch group.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+
+			// Actions.
+			0x00, 0x0c, // Copy TTL in.
+			0x00, 0x08, // Action length.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+
+			0x00, 0x18, // Length.
+			0x00, 0x14, // Wight.
+			0x00, 0x00, 0x00, 0x03, // Watch port.
+			0x00, 0x00, 0x00, 0x06, // Watch group.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+
+			// Actions.
+			0x00, 0x0b, // Copy TTL out.
+			0x00, 0x08, // Action length.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+		}},
+	}
+
+	gob.Register(ActionCopyTTLOut{})
+	encodingtest.RunMU(t, tests)
+}
+
 func TestBucketCounter(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&BucketCounter{
@@ -59,6 +109,17 @@ func TestBucketCounter(t *testing.T) {
 		}, []byte{
 			0x4c, 0xa7, 0xfc, 0x26, 0x1b, 0x61, 0xd4, 0xb1,
 			0xcc, 0x2f, 0x60, 0x91, 0xbe, 0x06, 0x98, 0xa7,
+		}},
+	}
+
+	encodingtest.RunMU(t, tests)
+}
+
+func TestGroupStatsRequest(t *testing.T) {
+	tests := []encodingtest.MU{
+		{&GroupStatsRequest{Group(7)}, []byte{
+			0x00, 0x00, 0x00, 0x07, // Group identifier.
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
 		}},
 	}
 

--- a/ofp.v13/queue.go
+++ b/ofp.v13/queue.go
@@ -243,21 +243,7 @@ func (q *QueueGetConfigReply) ReadFrom(r io.Reader) (int64, error) {
 	// OpenFlow message, thus return EOF error when the
 	// messages ends. Otherwise this implementation will
 	// read the packet queues indefinitely.
-	var queues []PacketQueue
-	for {
-		var queue PacketQueue
-		nn, err := queue.ReadFrom(r)
-		n += nn
-
-		if err != nil {
-			return n, encoding.SkipEOF(err)
-		}
-
-		queues = append(queues, queue)
-	}
-
-	// Assign the list of queues back to the reply to
-	// make the unmarshaling reproducable.
-	q.Queues = queues
-	return n, nil
+	queueMaker := encoding.ReaderMakerOf(PacketQueue{})
+	nn, err := encoding.ReadSliceFrom(r, queueMaker, q.Queues)
+	return n + nn, err
 }


### PR DESCRIPTION
This patch provides implementation of the OpenFlow group modification
message marshaling. It also contains a new function encoding.ReadSliceFrom
to encapsulate the logic of reading slices used in many parts of ofp
package.