### PR TITLE
Exclusive access to the response writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ of.ListenAndServe(":6633", nil)
 ```
 
 ```go
-tm := &TypeMatcher{Type: TypePacketIn}
+tm := &TypeMatcher{Type: of.TypePacketIn}
 m := &of.RequestMatcher{tm}
 
 d := NewRequestDispatcher()

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -16,8 +16,8 @@ func TestTypeDispatcher(t *testing.T) {
 	rd.HandleFunc(TypeHello, func(rw ResponseWriter, r *Request) {
 		defer wg.Done()
 
-		rw.Write([]byte{0, 0, 0, 0})
-		rw.WriteHeader(r.Header.Copy())
+		wbuf := bytes.NewBuffer([]byte{0, 0, 0, 0})
+		rw.Write(r.Header.Copy(), wbuf)
 	})
 
 	reader := bytes.NewBuffer([]byte{4, 0, 0, 8, 0, 0, 0, 0})

--- a/request.go
+++ b/request.go
@@ -48,9 +48,9 @@ type Request struct {
 
 // NewRequest returns a new Request given a type, address, and optional
 // body.
-func NewRequest(t Type, body ...io.WriterTo) (*Request, error) {
+func NewRequest(t Type, body io.WriterTo) (*Request, error) {
 	req := &Request{
-		Body:       newReader(body...),
+		Body:       newReader(body),
 		Proto:      "OFP/1.3",
 		ProtoMajor: 1, ProtoMinor: 3,
 	}


### PR DESCRIPTION
This patch modifies an interface of the ```ResponseWriter```. It removes
the method ```WriteHeader```, in order to address the problem with ```Write```
atomicity.

As the ```ResponseWriter``` shares the same underlying connection
between multiple handlers, we un-intentionally put the Write-WriteHeader
method calls into the race condition. To mitigate this, I reduced the count
of methods, that provides ```ResponseWriter``` to a single one.