### PR TITLE
Cookie matcher function

### DIFF
--- a/cookie_test.go
+++ b/cookie_test.go
@@ -42,3 +42,12 @@ func TestCookieReaderOf(t *testing.T) {
 		t.Fatalf("Invalid cookie returned: %d", jar.Cookies)
 	}
 }
+
+func TestNewCookieMatcher(t *testing.T) {
+	jar := &fakeCookieJar{}
+	m := NewCookieMatcher(jar)
+
+	if m.Cookies != jar.Cookies() {
+		t.Fatalf("Cookies are not set: %d != %d", m.Cookies, jar.Cookies())
+	}
+}


### PR DESCRIPTION
This patch introduces a cookie matcher contructor used to
bound the randomly-generated cookie value with a request
matcher instance.