### PR TITLE
Docker image with Open vSwitch and Mininet

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:sid
+
+# Install Open vSwtich and mininet to create custom topologies.
+RUN apt-get update \
+    && apt-get install -y \
+        openvswitch-switch \
+        net-tools \
+        mininet \
+    && apt-get clean
+
+# Create a run directory for Open vSwitch daemons.
+RUN mkdir -p /var/run/openvswitch
+COPY binaries/docker-entrypoint.sh /usr/bin/docker-entrypoint
+
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["ovs-vswitchd", "--pidfile"]

--- a/test/binaries/docker-entrypoint.sh
+++ b/test/binaries/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+ovs_db_socket=/var/run/openvswitch/db.sock
+
+sysctl -w net.ipv4.ip_forward=1
+sysctl -w net.ipv6.conf.all.forwarding=1
+
+# Initialize configuration database.
+ovsdb-tool create /etc/openvswitch/conf.db \
+    /usr/share/openvswitch/vswitch.ovsschema
+
+# Start the OVS database server in the detached mode.
+ovsdb-server \
+    --detach --pidfile \
+    --remote=punix:${ovs_db_socket} \
+    --remote=db:Open_vSwitch,Open_vSwitch,manager_options
+
+# Initialized OVS database.
+ovs-vsctl --db=unix:${ovs_db_socket} --no-wait init
+exec "$@"


### PR DESCRIPTION
This patch provides the Dockerfile used to build an environment
for testing functional testing of the OpenFlow library.