### PR TITLE
Update documentation of description message

### DIFF
--- a/ofp/description.go
+++ b/ofp/description.go
@@ -7,34 +7,63 @@ import (
 )
 
 const (
-	descLen      = 256
+	// descLen is a length of the maximum length of the description
+	// attributes (e.g. manufacturer, hardware, software).
+	descLen = 256
+
+	// serialNumLen is a length of the switch serial number.
 	serialNumLen = 32
 )
 
+// Description is an information about the switch manufacturer, hardware
+// revision, software revision, serial number, and a description field.
+//
+// This message is used as a response body of multipart request. For
+// example, to retrieve detailed description about the switch, the
+// following request could be sent:
+//
+//	req := ofp.NewMultipartRequest(
+//		ofp.MultipartTypeDescription, nil)
+//	...
 type Description struct {
+	// Manufacturer description.
 	Manufacturer string
-	Hardware     string
-	Software     string
-	SerialNum    string
-	Datapath     string
+
+	// Hardware description.
+	Hardware string
+
+	// Software description.
+	Software string
+
+	// Serial number.
+	SerialNum string
+
+	// Human readable description of datapath.
+	Datapath string
 }
 
-func (d *Description) cpTo(s string, length int) []byte {
+// copyTo copies the specified string into the slice of bytes of given
+// length.
+func (d *Description) copyTo(s string, length int) []byte {
 	b := make([]byte, length)
 	copy(b, []byte(s))
 	return b
 }
 
+// WriteTo implements io.WriterTo interface. It serializes the switch
+// description into the wire format.
 func (d *Description) WriteTo(w io.Writer) (int64, error) {
-	mfr := d.cpTo(d.Manufacturer, descLen)
-	hw := d.cpTo(d.Hardware, descLen)
-	sw := d.cpTo(d.Software, descLen)
-	sn := d.cpTo(d.SerialNum, serialNumLen)
-	dp := d.cpTo(d.Datapath, descLen)
+	mfr := d.copyTo(d.Manufacturer, descLen)
+	hw := d.copyTo(d.Hardware, descLen)
+	sw := d.copyTo(d.Software, descLen)
+	sn := d.copyTo(d.SerialNum, serialNumLen)
+	dp := d.copyTo(d.Datapath, descLen)
 
 	return encoding.WriteTo(w, mfr, hw, sw, sn, dp)
 }
 
+// ReadFrom implements io.ReadFrom interface. It deserializes the
+// switch description from the wire format.
 func (d *Description) ReadFrom(r io.Reader) (int64, error) {
 	var mfr, hw, sw, dp [descLen]byte
 	var sn [serialNumLen]byte

--- a/ofp/multipart.go
+++ b/ofp/multipart.go
@@ -146,10 +146,15 @@ type MultipartRequest struct {
 
 // NewMultipartRequest creates a new multipart request.
 func NewMultipartRequest(t MultipartType, body io.WriterTo) *MultipartRequest {
-	return &MultipartRequest{
-		Type: t, Flags: MultipartRequestMode,
-		Body: &reader{WriterTo: body},
+	var rd io.Reader
+
+	// When the body is not defined then bypass wrapping
+	// it with a reader type.
+	if body != nil {
+		rd = &reader{WriterTo: body}
 	}
+
+	return &MultipartRequest{t, MultipartRequestMode, rd}
 }
 
 func (m *MultipartRequest) WriteTo(w io.Writer) (int64, error) {


### PR DESCRIPTION
This patch updates the documentation of the description message.
It also makes it possible to create a multipart request with a nil-body.

closes #67