### PR TITLE
Update documentation of instructions

### DIFF
--- a/ofp/action.go
+++ b/ofp/action.go
@@ -157,7 +157,7 @@ type Action interface {
 	Type() ActionType
 }
 
-// Actions groups the set of actions.
+// Actions group the set of actions.
 type Actions []Action
 
 func (a *Actions) bytes() ([]byte, error) {

--- a/ofp/group.go
+++ b/ofp/group.go
@@ -49,7 +49,7 @@ const (
 	// GroupAll represents all groups for group delete commands.
 	GroupAll Group = 0xfffffffc
 
-	// GropAny is a wildcard group used only for flow stats requests.
+	// GroupAny is a wildcard group used only for flow stats requests.
 	// Selects all flows regardless of group (including flows with no
 	// group)
 	GroupAny Group = 0xffffffff

--- a/ofp/handshake.go
+++ b/ofp/handshake.go
@@ -243,7 +243,7 @@ func (rr *RoleRequest) WriteTo(w io.Writer) (int64, error) {
 	return encoding.WriteTo(w, rr.Role, pad4{}, rr.GenerationID)
 }
 
-// WriteTo implements io.WriterTo interface. It deserializes the role
+// ReadFrom implements io.ReaderFrom interface. It deserializes the role
 // request from the wire format.
 func (rr *RoleRequest) ReadFrom(r io.Reader) (int64, error) {
 	return encoding.ReadFrom(r, &rr.Role, &defaultPad4, &rr.GenerationID)


### PR DESCRIPTION
This patch updates the documentation of OpenFlow instructions.
It also fixes a few inconsistencies in the godoc of actions and
role requests.

closes #86 