### PR TITLE
Update documentation of packet in/out messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ func main() {
         fmod := ofp.NewFlowMod(ofp.FlowAdd, packet)
         fmod.Instructions = ofp.Instructions{apply}
 
-        rw.Write(&of.Header{Type: of.TypeFlowMod}, body)
+        rw.Write(&of.Header{Type: of.TypeFlowMod}, fmod)
     })
 
     of.ListenAndServe(":6633", mux)

--- a/ofp/flow.go
+++ b/ofp/flow.go
@@ -135,17 +135,17 @@ type FlowMod struct {
 	// entries.
 	Priority uint16
 
-	// The BufferID refers to a packet buffered at the switch and sent
+	// The Buffer refers to a packet buffered at the switch and sent
 	// to the controller by a packet-in message.
 	//
 	// If no buffered packet is associated with the flow mod, it must be
 	// set to NoBuffer.
 	//
-	// A flow mod that includes a valid BufferID is effectively equivalent
+	// A flow mod that includes a valid Buffer is effectively equivalent
 	// to sending a two-message sequence of a flow mod and a packet-out to
 	// PortTable, with the requirement that the switch must fully process
 	// the flow mod before the packet out.
-	BufferID uint32
+	Buffer uint32
 
 	// For flow deletion commands, require matching entries to include
 	// this as an output port. A value of PortAny indicates no restriction.
@@ -193,14 +193,14 @@ func NewFlowMod(c FlowModCommand, p *PacketIn) *FlowMod {
 	var match Match
 
 	if p != nil {
-		buffer, match = p.BufferID, p.Match
+		buffer, match = p.Buffer, p.Match
 	}
 
 	return &FlowMod{
-		Command:  c,
-		BufferID: buffer,
-		Match:    match,
-		Flags:    flags,
+		Command: c,
+		Buffer:  buffer,
+		Match:   match,
+		Flags:   flags,
 
 		// For FlowDelete command, define the output port and
 		// group values as "any" to indicate no restrictions.
@@ -225,7 +225,7 @@ func (f *FlowMod) SetCookies(cookies uint64) {
 func (f *FlowMod) WriteTo(w io.Writer) (int64, error) {
 	return encoding.WriteTo(w, f.Cookie, f.CookieMask, f.Table,
 		f.Command, f.IdleTimeout, f.HardTimeout, f.Priority,
-		f.BufferID, f.OutPort, f.OutGroup, f.Flags, pad2{},
+		f.Buffer, f.OutPort, f.OutGroup, f.Flags, pad2{},
 		&f.Match, &f.Instructions,
 	)
 }
@@ -239,7 +239,7 @@ func (f *FlowMod) ReadFrom(r io.Reader) (int64, error) {
 
 	return encoding.ReadFrom(r, &f.Cookie, &f.CookieMask, &f.Table,
 		&f.Command, &f.IdleTimeout, &f.HardTimeout, &f.Priority,
-		&f.BufferID, &f.OutPort, &f.OutGroup, &f.Flags, &defaultPad2,
+		&f.Buffer, &f.OutPort, &f.OutGroup, &f.Flags, &defaultPad2,
 		&f.Match, &f.Instructions,
 	)
 }

--- a/ofp/flow_test.go
+++ b/ofp/flow_test.go
@@ -28,7 +28,7 @@ func TestFlowMod(t *testing.T) {
 			IdleTimeout:  45,
 			HardTimeout:  90,
 			Priority:     10,
-			BufferID:     NoBuffer,
+			Buffer:       NoBuffer,
 			OutPort:      PortFlood,
 			OutGroup:     GroupAny,
 			Flags:        flags,
@@ -219,7 +219,7 @@ func TestNewFlowMod(t *testing.T) {
 		Value: XMValue{0x00, 0x00, 0x00, 0x03},
 	}}}
 
-	packet := &PacketIn{BufferID: 42, Match: match}
+	packet := &PacketIn{Buffer: 42, Match: match}
 	fmod := NewFlowMod(FlowAdd, packet)
 
 	// Ensure that all default parameters of the created
@@ -228,9 +228,9 @@ func TestNewFlowMod(t *testing.T) {
 		t.Errorf("Default flags are not set: %b", fmod.Flags)
 	}
 
-	if fmod.BufferID != packet.BufferID {
+	if fmod.Buffer != packet.Buffer {
 		t.Errorf("Buffer identifier does not match expected one: "+
-			"%d is not equal to %d", fmod.BufferID, packet.BufferID)
+			"%d is not equal to %d", fmod.Buffer, packet.Buffer)
 	}
 
 	if !reflect.DeepEqual(fmod.Match, match) {

--- a/ofp/packet_test.go
+++ b/ofp/packet_test.go
@@ -9,11 +9,11 @@ import (
 func TestPacketIn(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&PacketIn{
-			BufferID: NoBuffer,
-			Length:   0x20,
-			Reason:   PacketInReasonAction,
-			TableID:  Table(2),
-			Cookie:   0xdeadbeef,
+			Buffer: NoBuffer,
+			Length: 0x20,
+			Reason: PacketInReasonAction,
+			Table:  Table(2),
+			Cookie: 0xdeadbeef,
 			Match: Match{MatchTypeXM, []XM{{
 				Class: XMClassOpenflowBasic,
 				Type:  XMTypeInPort,
@@ -46,9 +46,9 @@ func TestPacketIn(t *testing.T) {
 func TestPacketOut(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&PacketOut{
-			BufferID: NoBuffer,
-			InPort:   PortController,
-			Actions:  Actions{&ActionGroup{Group: GroupAll}},
+			Buffer:  NoBuffer,
+			InPort:  PortController,
+			Actions: Actions{&ActionGroup{Group: GroupAll}},
 		}, []byte{
 			0xff, 0xff, 0xff, 0xff, // Buffer identifier.
 			0xff, 0xff, 0xff, 0xfd, // Port number.

--- a/ofputil/flow.go
+++ b/ofputil/flow.go
@@ -9,7 +9,7 @@ func TableFlush(table ofp.Table) *of.Request {
 	return of.NewRequest(of.TypeFlowMod, &ofp.FlowMod{
 		Table:    table,
 		Command:  ofp.FlowDelete,
-		BufferID: ofp.NoBuffer,
+		Buffer:   ofp.NoBuffer,
 		OutPort:  ofp.PortAny,
 		OutGroup: ofp.GroupAny,
 		Match:    ofp.Match{ofp.MatchTypeXM, nil},
@@ -20,7 +20,7 @@ func FlowFlush(table ofp.Table, match ofp.Match) *of.Request {
 	return of.NewRequest(of.TypeFlowMod, &ofp.FlowMod{
 		Table:    table,
 		Command:  ofp.FlowDelete,
-		BufferID: ofp.NoBuffer,
+		Buffer:   ofp.NoBuffer,
 		OutPort:  ofp.PortAny,
 		OutGroup: ofp.GroupAny,
 		Match:    match,
@@ -29,9 +29,9 @@ func FlowFlush(table ofp.Table, match ofp.Match) *of.Request {
 
 func FlowDrop(table ofp.Table) *of.Request {
 	return of.NewRequest(of.TypeFlowMod, &ofp.FlowMod{
-		Table:    table,
-		Command:  ofp.FlowAdd,
-		BufferID: ofp.NoBuffer,
-		Match:    ofp.Match{ofp.MatchTypeXM, nil},
+		Table:   table,
+		Command: ofp.FlowAdd,
+		Buffer:  ofp.NoBuffer,
+		Match:   ofp.Match{ofp.MatchTypeXM, nil},
 	})
 }


### PR DESCRIPTION
This patch updates the documentation of Packet In/Out messages
with a simple examples. It also renames the BufferID to the Buffer
for the sake of simlicity.

closes #94 