### PR TITLE
Correct multiple typos in the ofp package

### DIFF
--- a/ofp/action.go
+++ b/ofp/action.go
@@ -146,7 +146,7 @@ type action struct {
 	Len uint16
 }
 
-// actionLen is a minum length of the action.
+// actionLen is a minimum length of the action.
 const actionLen uint16 = 8
 
 // Action is an interface representing an OpenFlow action.
@@ -183,7 +183,7 @@ func (a *Actions) WriteTo(w io.Writer) (int64, error) {
 	return encoding.WriteTo(w, buf)
 }
 
-// ReadFrom decores the list of actions from the wire format into
+// ReadFrom decodes the list of actions from the wire format into
 // the list of types that implement Action interface.
 func (a *Actions) ReadFrom(r io.Reader) (int64, error) {
 	var actionType ActionType
@@ -450,7 +450,7 @@ func (a *ActionSetQueue) ReadFrom(r io.Reader) (int64, error) {
 	return encoding.ReadFrom(r, &defaultPad4, &a.QueueID)
 }
 
-// ActionGroup is an action that specifis the group used to process
+// ActionGroup is an action that specifies the group used to process
 // the packet.
 type ActionGroup struct {
 	// The Group indicates the group used to process this packet.

--- a/ofp/flow.go
+++ b/ofp/flow.go
@@ -368,7 +368,7 @@ type FlowStatsRequest struct {
 	// Require matching entries to contain this cookie value.
 	Cookie uint64
 
-	// Mask used to retstrict the cookie bits that must match. A zero
+	// Mask used to restrict the cookie bits that must match. A zero
 	// value indicates no restrictions.
 	CookieMask uint64
 

--- a/ofp/group.go
+++ b/ofp/group.go
@@ -81,7 +81,7 @@ type GroupMod struct {
 	// Group identifier.
 	Group Group
 
-	// Buckets is an array of buckets. For inderect group type, the
+	// Buckets is an array of buckets. For indirect group type, the
 	// array must contain exactly one bucket, other group types may
 	// have multiple buckets in the array.
 	//
@@ -103,7 +103,7 @@ func (g *GroupMod) WriteTo(w io.Writer) (int64, error) {
 	return n + nn, err
 }
 
-// ReadFrom implementa io.ReaderFrom interface. It deserializes the
+// ReadFrom implements io.ReaderFrom interface. It deserializes the
 // groups modification message from the wire format.
 func (g *GroupMod) ReadFrom(r io.Reader) (int64, error) {
 	n, err := encoding.ReadFrom(r, &g.Command, &g.Type,

--- a/ofp/handshake.go
+++ b/ofp/handshake.go
@@ -57,7 +57,7 @@ func (h HelloElems) WriteTo(w io.Writer) (int64, error) {
 	return encoding.WriteTo(w, buf.Bytes())
 }
 
-// ReadFrom implements io.ReaderFrom interface. It desrializes the
+// ReadFrom implements io.ReaderFrom interface. It deserializes the
 // list of hello elements from the wire format.
 func (h HelloElems) ReadFrom(r io.Reader) (int64, error) {
 	var helloElemType HelloElemType
@@ -77,13 +77,13 @@ func (h HelloElems) ReadFrom(r io.Reader) (int64, error) {
 		encoding.ReaderMakerFunc(rm))
 }
 
-// Hello is a message used to performat an initial handshake right after
+// Hello is a message used to perform an initial handshake right after
 // establishing the connection. It is used to negotiate the version of
 // the protocol to communicate.
 //
 // For example, to create a hello message in order to response on the
 // incoming message from the datapath, the following request could be
-// consucted to inform that controller supports only OpenFlow 1.3:
+// constructed to inform that controller supports only OpenFlow 1.3:
 //
 //	req := of.NewRequest(of.HelloType, &ofp.Hello{
 //		ofp.HelloElems{&ofp.HelloElemVersionBitmap{
@@ -138,7 +138,7 @@ func (h *HelloElemVersionBitmap) WriteTo(w io.Writer) (int64, error) {
 	// used to align the message to 64-bits border.
 	totalLen := helloElemLen + maplen + len(padding)
 
-	// Compose the healder of the element and marshal it
+	// Compose the header of the element and marshal it
 	// altogether with a version bitmaps and required padding.
 	header := helloElem{h.Type(), uint16(totalLen)}
 	return encoding.WriteTo(w, header, h.Bitmaps, padding)
@@ -147,7 +147,7 @@ func (h *HelloElemVersionBitmap) WriteTo(w io.Writer) (int64, error) {
 // ReadFrom implements io.ReaderFrom interface. It deserializes the
 // version bitmap from the wire format.
 func (h *HelloElemVersionBitmap) ReadFrom(r io.Reader) (int64, error) {
-	// Read the header of the version bitmaps to retireve
+	// Read the header of the version bitmaps to retrieve
 	// the total length of the message.
 	var header helloElem
 	n, err := encoding.ReadFrom(r, &header)

--- a/ofp/instruction.go
+++ b/ofp/instruction.go
@@ -172,7 +172,7 @@ func (i *InstructionWriteMetadata) ReadFrom(r io.Reader) (int64, error) {
 		&defaultPad4, &i.Metadata, &i.MetadataMask)
 }
 
-// writeIntructionActions serializes the instruction with actinon.
+// writeIntructionActions serializes the instruction with action.
 // It is shared among the Appply/Clear/Write instructions.
 func writeInstructionActions(w io.Writer, t InstructionType,
 	actions Actions) (int64, error) {
@@ -191,7 +191,7 @@ func writeInstructionActions(w io.Writer, t InstructionType,
 	return encoding.WriteTo(w, header, pad4{}, buf)
 }
 
-// readInstructionActions deserializes the instructin with actions.
+// readInstructionActions deserializes the instruction with actions.
 // It is shared among the Apply/Clear/Write instructions.
 func readInstructionActions(r io.Reader, actions Actions) (int64, error) {
 	var read int64

--- a/ofp/meter.go
+++ b/ofp/meter.go
@@ -18,7 +18,7 @@ const (
 	// MeterModify is a command used to modify specified meter.
 	MeterModify
 
-	// MeterDelete is a command used to delete specicifed meter.
+	// MeterDelete is a command used to delete specified meter.
 	MeterDelete
 )
 
@@ -167,7 +167,7 @@ func (m *MeterBandDrop) ReadFrom(r io.Reader) (int64, error) {
 		&m.Rate, &m.BurstSize, &defaultPad4)
 }
 
-// MeterBandDSCPRemark defines a simple differentiated services policer
+// MeterBandDSCPRemark defines a simple differentiated services police
 // that remark the drop procedure of the DSCP field in the IP header of
 // the packets that exceed the band rate value.
 type MeterBandDSCPRemark struct {
@@ -215,7 +215,7 @@ type MeterBandExperimenter struct {
 	Experimenter uint32
 }
 
-// Type implements MeterBand interface. It returs the type of the
+// Type implements MeterBand interface. It returns the type of the
 // meter band.
 func (m *MeterBandExperimenter) Type() MeterBandType {
 	return MeterBandTypeExperimenter
@@ -468,7 +468,7 @@ func (m *MeterStats) WriteTo(w io.Writer) (int64, error) {
 	var buf bytes.Buffer
 
 	// Write the list of meter band statistics into
-	// the termporary buffer to calculate the total
+	// the temporary buffer to calculate the total
 	// message length.
 	_, err := encoding.WriteSliceTo(&buf, m.BandStats)
 	if err != nil {

--- a/ofp/multipart.go
+++ b/ofp/multipart.go
@@ -222,7 +222,7 @@ func (m *MultipartRequest) ReadFrom(r io.Reader) (int64, error) {
 		return n, err
 	}
 
-	// Just copy the rest of the body to the requet.
+	// Just copy the rest of the body to the request.
 	buf := new(bytes.Buffer)
 	m.Body = buf
 

--- a/ofp/port.go
+++ b/ofp/port.go
@@ -72,7 +72,7 @@ const (
 	PortFeaturePause
 
 	// PortFeaturePauseAsym is set when the port supports flow control
-	// through the assymetric pause frames.
+	// through the asymmetric pause frames.
 	PortFeaturePauseAsym
 )
 
@@ -163,7 +163,7 @@ var portConfigText = []struct {
 func (c PortConfig) String() string {
 	var configs []string
 
-	// When the port is not DOWN, we will atomatically assume
+	// When the port is not DOWN, we will automatically assume
 	// it is UP and append the respective text message.
 	if PortConfigDown&c == 0 {
 		configs = append(configs, "up")
@@ -238,7 +238,7 @@ const (
 	// PortController used to send the received packet to controller.
 	PortController PortNo = 0xfffffff8 + iota
 
-	// PortLocal is a local openflow port.
+	// PortLocal is a local OpenFlow port.
 	PortLocal PortNo = 0xfffffff8 + iota
 
 	// PortAny is a wildcard port used only for flow mod (delete) and
@@ -255,10 +255,10 @@ const portNameLen = 16
 
 // Port defines the description of the switch port. This structure is
 // returned within a body of the multipart request, used to get a
-// description of all the ports in the sytem that support OpenFlow.
+// description of all the ports in the system that support OpenFlow.
 //
-// For example, to retireve the description of port on the system, the
-// following requet can be created:
+// For example, to retrieve the description of port on the system, the
+// following request can be created:
 //
 //	body := ofp.NewMultipartRequest(ofp.MultipartTypePortDescription, nil)
 //	req := of.NewRequest(of.TypeMultipartRequest, body)
@@ -303,7 +303,7 @@ func (p *Port) WriteTo(w io.Writer) (int64, error) {
 }
 
 // ReadFrom implements io.ReaderFrom interface. It deserializes the
-// port desecription from the wire format.
+// port description from the wire format.
 func (p *Port) ReadFrom(r io.Reader) (int64, error) {
 	p.HWAddr = make(net.HardwareAddr, 6)
 	var name [portNameLen]byte
@@ -393,11 +393,11 @@ func (p *PortMod) ReadFrom(r io.Reader) (int64, error) {
 	)
 }
 
-// PortReason defines types of changes beign made about physical port.
+// PortReason defines types of changes being made about physical port.
 type PortReason uint8
 
 const (
-	// PortReasonAdd indecates that port was added.
+	// PortReasonAdd indicates that port was added.
 	PortReasonAdd PortReason = iota
 
 	// PortReasonDelete indicates that port was removed.
@@ -409,7 +409,7 @@ const (
 )
 
 // PortStatus is the message used by the switch to inform the controller
-// about the port beign added, modified or removed.
+// about the port being added, modified or removed.
 type PortStatus struct {
 	// Reason is the reason of this message.
 	Reason PortReason
@@ -474,7 +474,7 @@ type PortStats struct {
 	// RxBytes is a number of received bytes.
 	RxBytes uint64
 
-	// TxBytes is anumber of transmitted bytes.
+	// TxBytes is a number of transmitted bytes.
 	TxBytes uint64
 
 	// RxDropped is a number of packets dropped by RX.

--- a/ofp/queue.go
+++ b/ofp/queue.go
@@ -87,7 +87,7 @@ func (q QueueProps) ReadFrom(r io.Reader) (int64, error) {
 		encoding.ReaderMakerFunc(rm))
 }
 
-// packetQueueLen defines the lenght of the packet queue header.
+// packetQueueLen defines the length of the packet queue header.
 const packetQueueLen = 16
 
 // PacketQueue decribes the packet processing queue.

--- a/ofp/switch.go
+++ b/ofp/switch.go
@@ -52,7 +52,7 @@ const (
 	//
 	// This type of fragments handling means that an attempt should be
 	// made to pass the fragments through the OpenFlow tables. If any
-	// field is not present (e.g., the TCP/UDP ports didn’t fit), then
+	// field is not present (e.g., the TCP/UDP ports didn't fit), then
 	// the packet should not match any entry that has that field set.
 	ConfigFlagFragNormal ConfigFlag = iota
 


### PR DESCRIPTION
This patch fixes several typos in the ofp package.