### PR TITLE
Feature server max connections

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -1,8 +1,23 @@
 package openflow
 
 import (
+	"bytes"
 	"testing"
 )
+
+// newHeader creates a new header with a given type and returns a wire
+// representation of the created instance. Panics if error returns.
+func newHeader(t Type) []byte {
+	header := &Header{Version: 4, Type: t, Length: 8}
+
+	var buf bytes.Buffer
+	_, err := header.WriteTo(&buf)
+	if err != nil {
+		panic(err)
+	}
+
+	return buf.Bytes()
+}
 
 func TestTransactionMatcher(t *testing.T) {
 	header := new(Header)

--- a/mux_test.go
+++ b/mux_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"sync"
 	"testing"
 )
@@ -57,11 +58,13 @@ func TestTypeMux(t *testing.T) {
 		t.Errorf("This handler should never be called")
 	})
 
-	reader := bytes.NewBuffer([]byte{4, 0, 0, 8, 0, 0, 0, 0})
+	reader := bytes.NewBuffer(newHeader(TypeHello))
 	conn := &dummyConn{r: *reader}
 
 	s := Server{Addr: "0.0.0.0:6633", Handler: mux}
-	err := s.Serve(&dummyListener{conn})
+	defer s.close()
+
+	err := s.Serve(&dummyListener{[]net.Conn{conn}})
 
 	// Serve function will treat the connection as a regular
 	// connection, thus will try to read the next message after

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,69 @@
+package openflow
+
+import (
+	"io"
+	"net"
+	"testing"
+)
+
+func TestReceiver(t *testing.T) {
+	dconn := new(dummyConn)
+	dconn.r.Write(newHeader(TypeHello))
+
+	rcvr := &receiver{Conn: newConn(dconn)}
+	wrap := <-rcvr.C()
+
+	if wrap.err != nil {
+		t.Fatalf("Error returned from receiver: %s", wrap.err)
+	}
+
+	htype := wrap.req.Header.Type
+	if htype != TypeHello {
+		t.Fatalf("Incorrect request type returned: %d", htype)
+	}
+
+	// Receive of another request should fail with EOF.
+	wrap = <-rcvr.C()
+	if wrap.err != io.EOF {
+		t.Fatalf("Expected EOF on second receive: %s", wrap.err)
+	}
+
+	_, ok := <-rcvr.C()
+	if ok {
+		t.Fatalf("Channel should be closed on error")
+	}
+}
+
+func TestServeMaxConns(t *testing.T) {
+	s := Server{MaxConns: 2}
+	defer s.close()
+
+	// Create three connection, with a maximum connections set to two.
+	// This means, a third client should be closed by the server.
+	dconn1 := new(dummyBlockConn)
+	dconn2 := new(dummyBlockConn)
+	dconn3 := new(dummyBlockConn)
+
+	defer dconn1.Close()
+	defer dconn2.Close()
+
+	dln := &dummyListener{[]net.Conn{dconn1, dconn2, dconn3}}
+	err := s.Serve(dln)
+
+	// The mock of the listener returns an error, when connections
+	// have been extracted from the queue completely.
+	if err != io.EOF {
+		t.Errorf("Serving of the listener failed: %s", err)
+	}
+
+	if dconn1.closed || dconn2.closed {
+		t.Errorf("Two first connection expected to be alive")
+	}
+
+	if !dconn3.closed {
+		t.Errorf("Third connection expected to be closed")
+	}
+}
+
+func TestServerServe(t *testing.T) {
+}


### PR DESCRIPTION
This patch adds a MaxConns parameter, that limits a number of
simultaneous connections, that Server can handle at a time.
All connections over that limit will be explicitly closed.