### PR TITLE
server: connection state transition test

### DIFF
--- a/net.go
+++ b/net.go
@@ -12,7 +12,7 @@ type ConnState int
 
 const (
 	StateNew ConnState = iota
-	StateHelloReceived
+	StateHandshake
 	StateActive
 	StateIdle
 	StateClosed

--- a/server.go
+++ b/server.go
@@ -293,7 +293,7 @@ func (srv *Server) serve(c *conn, h Handler) {
 func (srv *Server) serveReq(c *conn, req *Request, h Handler) {
 	state := StateActive
 	if req.Header.Type == TypeHello {
-		state = StateHelloReceived
+		state = StateHandshake
 	}
 
 	srv.setState(c, state)


### PR DESCRIPTION
This patch adds the connection state transition test. It simply
validates the client connection have been transitioned though all
required tests.

It also changes the state name "StateHelloReceived" to "StateHandshake".