### PR TITLE
Refactoring of table feature properties decoding

### DIFF
--- a/ofp/action.go
+++ b/ofp/action.go
@@ -17,7 +17,7 @@ func (a ActionType) String() string {
 	text, ok := actionText[a]
 	// If action is now known just say it.
 	if !ok {
-		return "ActionUnknown"
+		return fmt.Sprintf("Action(%d)", a)
 	}
 
 	return text
@@ -88,23 +88,23 @@ const (
 )
 
 var actionText = map[ActionType]string{
-	ActionTypeOutput:       "ActionTypeOutput",
-	ActionTypeCopyTTLOut:   "ActionTypeCopyTTLOut",
-	ActionTypeCopyTTLIn:    "ActionTypeCopyTTLIn",
-	ActionTypeSetMPLSTTL:   "ActionTypeSetMPLSTTL",
-	ActionTypeDecMPLSTTL:   "ActionTypeDecMPLSTTL",
-	ActionTypePushVLAN:     "ActionTypePushVLAN",
-	ActionTypePopVLAN:      "ActionTypePopVLAN",
-	ActionTypePushMPLS:     "ActionTypePushMPLS",
-	ActionTypePopMPLS:      "ActionTypePopMPLS",
-	ActionTypeSetQueue:     "ActionTypeSetQueue",
-	ActionTypeGroup:        "ActionTypeGroup",
-	ActionTypeSetNwTTL:     "ActionTypeSetNwTTL",
-	ActionTypeDecNwTTL:     "ActionTypeDecNwTTL",
-	ActionTypeSetField:     "ActionTypeSetField",
-	ActionTypePushPBB:      "ActionTypePushPBB",
-	ActionTypePopPBB:       "ActionTypePopPBB",
-	ActionTypeExperimenter: "ActionTypeExperimenter",
+	ActionTypeOutput:       "ActionOutput",
+	ActionTypeCopyTTLOut:   "ActionCopyTTLOut",
+	ActionTypeCopyTTLIn:    "ActionCopyTTLIn",
+	ActionTypeSetMPLSTTL:   "ActionSetMPLSTTL",
+	ActionTypeDecMPLSTTL:   "ActionDecMPLSTTL",
+	ActionTypePushVLAN:     "ActionPushVLAN",
+	ActionTypePopVLAN:      "ActionPopVLAN",
+	ActionTypePushMPLS:     "ActionPushMPLS",
+	ActionTypePopMPLS:      "ActionPopMPLS",
+	ActionTypeSetQueue:     "ActionSetQueue",
+	ActionTypeGroup:        "ActionGroup",
+	ActionTypeSetNwTTL:     "ActionSetNwTTL",
+	ActionTypeDecNwTTL:     "ActionDecNwTTL",
+	ActionTypeSetField:     "ActionSetField",
+	ActionTypePushPBB:      "ActionPushPBB",
+	ActionTypePopPBB:       "ActionPopPBB",
+	ActionTypeExperimenter: "ActionExperimenter",
 }
 
 var actionMap = map[ActionType]encoding.ReaderMaker{
@@ -146,8 +146,17 @@ type action struct {
 	Len uint16
 }
 
-// actionLen is a minimum length of the action.
-const actionLen uint16 = 8
+func (a *action) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &a.Type, &a.Len)
+}
+
+const (
+	// actionLen is a minimum length of the action.
+	actionLen uint16 = 8
+
+	// actionHeaderLen is a length of the action header.
+	actionHeaderLen uint16 = 4
+)
 
 // Action is an interface representing an OpenFlow action.
 type Action interface {

--- a/ofp/instruction.go
+++ b/ofp/instruction.go
@@ -39,6 +39,26 @@ const (
 // InstructionType represents a type of the flow modification instruction.
 type InstructionType uint16
 
+// String returns a string representation of instruction type.
+func (it InstructionType) String() string {
+	text, ok := instrctionText[it]
+	if !ok {
+		return fmt.Sprintf("Instruction(%d)", it)
+	}
+
+	return text
+}
+
+var instrctionText = map[InstructionType]string{
+	InstructionTypeGotoTable:     "InstructionGotoTable",
+	InstructionTypeWriteMetadata: "InstructionWriteMetadata",
+	InstructionTypeWriteActions:  "InstructionWriteActions",
+	InstructionTypeApplyActions:  "InstructionApplyActions",
+	InstructionTypeClearActions:  "InstructionClearActions",
+	InstructionTypeMeter:         "InstructionMeter",
+	InstructionTypeExperimenter:  "InstructionExperimenter",
+}
+
 var instructionMap = map[InstructionType]encoding.ReaderMaker{
 	InstructionTypeGotoTable:     encoding.ReaderMakerOf(InstructionGotoTable{}),
 	InstructionTypeWriteMetadata: encoding.ReaderMakerOf(InstructionWriteMetadata{}),
@@ -61,7 +81,17 @@ type instruction struct {
 	Len uint16
 }
 
-const instructionLen uint16 = 8
+func (i *instruction) ReadFrom(r io.Reader) (int64, error) {
+	return encoding.ReadFrom(r, &i.Type, &i.Len)
+}
+
+const (
+	// instructionLen is a minimum length of the instruction.
+	instructionLen uint16 = 8
+
+	// instructionHeaderLen is a length of the instruction header.
+	instructionHeaderLen uint16 = 4
+)
 
 // Instruction is an interface representing an OpenFlow action.
 type Instruction interface {

--- a/ofp/pad.go
+++ b/ofp/pad.go
@@ -23,3 +23,14 @@ var (
 	defaultPad7 pad7
 	defaultPad8 pad8
 )
+
+// padLen returns a size of the padding for the given length.
+func padLen(length int) int {
+	return (length+7)/8*8 - length
+}
+
+// makePad creates a new padding based on the given length according
+// to the formula: (length + 7) / 8 * 8 - length
+func makePad(length int) []byte {
+	return make([]byte, padLen(length))
+}

--- a/ofp/table_test.go
+++ b/ofp/table_test.go
@@ -42,30 +42,22 @@ func TestTableStats(t *testing.T) {
 }
 
 func TestTablePropInstructions(t *testing.T) {
-	instr := Instructions{
-		&InstructionMeter{Meter: Meter(4)},
-		&InstructionGotoTable{Table: Table(15)},
-	}
-
 	tests := []encodingtest.MU{
-		{&TablePropInstructions{
-			Instructions: instr,
-		}, []byte{
+		{&TablePropInstructions{Instructions: []InstructionType{
+			InstructionTypeMeter,
+			InstructionTypeGotoTable,
+		}}, []byte{
 			0x00, 0x00, // Property type.
-			0x00, 0x14, // Property length.
+			0x00, 0x0c, // Property length.
 
 			// Instructions.
 			0x00, 0x06, // Instruction type.
-			0x00, 0x08, // Instruction length.
-			0x00, 0x00, 0x00, 0x04, // Meter identifier.
+			0x00, 0x04, // Instruction length.
 
 			0x00, 0x01, // Instruction type.
-			0x00, 0x08, // Instruction length.
-			0x0f,             // Table identifier.
-			0x00, 0x00, 0x00, // 3-byte padding.
+			0x00, 0x04, // Instruction length.
 
-			// Alignment.
-			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
 		}},
 	}
 
@@ -95,29 +87,22 @@ func TestTablePropNextTables(t *testing.T) {
 }
 
 func TestTablePropWriteActions(t *testing.T) {
-	actions := Actions{
-		&ActionCopyTTLOut{},
-		&ActionCopyTTLIn{},
-	}
-
 	tests := []encodingtest.MU{
-		{&TablePropWriteActions{
-			Actions: actions,
-		}, []byte{
+		{&TablePropWriteActions{Actions: []ActionType{
+			ActionTypeCopyTTLOut,
+			ActionTypeCopyTTLIn,
+		}}, []byte{
 			0x00, 0x04, // Property type.
-			0x00, 0x14, // Property length.
+			0x00, 0x0c, // Property length.
 
 			// Actions.
 			0x00, 0xb, // Action type.
-			0x00, 0x08, // Action lenght.
-			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x00, 0x04, // Action lenght.
 
 			0x00, 0xc, // Action type.
-			0x00, 0x08, // Action length.
-			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
+			0x00, 0x04, // Action length.
 
-			// Alignment.
-			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, // 4-byte padding.
 		}},
 	}
 
@@ -127,21 +112,14 @@ func TestTablePropWriteActions(t *testing.T) {
 func TestTablePropApplyActions(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&TablePropApplyActions{
-			Miss: true,
-			Actions: Actions{
-				&ActionGroup{Group: GroupAll},
-			},
+			Miss: true, Actions: []ActionType{ActionTypeGroup},
 		}, []byte{
 			0x00, 0x07, // Property type.
-			0x00, 0x0c, // Property length.
+			0x00, 0x08, // Property length.
 
 			// Actions.
 			0x00, 0x16, // Action type.
-			0x00, 0x08, // Action length.
-			0xff, 0xff, 0xff, 0xfc, // Group identifier.
-
-			// Alignment.
-			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x04, // Action length.
 		}},
 	}
 
@@ -152,33 +130,30 @@ var fields = []XM{
 	{
 		Class: XMClassOpenflowBasic,
 		Type:  XMTypeUDPSrc,
-		Value: XMValue{0x00, 0x35},
-		Mask:  XMValue{0xff, 0xff},
 	},
 	{
 		Class: XMClassOpenflowBasic,
 		Type:  XMTypeInPort,
-		Value: XMValue{0x00, 0x00, 0x00, 0x03},
 	},
 }
 
 var fieldsBytes = []byte{
 	0x80, 0x00, // OpenFlow basic.
-	0x1f,                   // Match field + Mask flag.
-	0x04,                   // Payload length.
-	0x00, 0x35, 0xff, 0xff, // Payload.
+	0x1e, // Match field + Mask flag.
+	0x00, // Match length.
 
 	0x80, 0x00, // OpenFlow basic.
-	0x00,                   // Match field + Mask flag.
-	0x04,                   // Payload length.
-	0x00, 0x00, 0x00, 0x03, // Payload.
+	0x00, // Match field + Mask flag.
+	0x00, // Match length.
+
+	0x00, 0x00, 0x00, 0x00, // 4-byte padding.
 }
 
 func TestTablePropMatch(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&TablePropMatch{Fields: fields}, append([]byte{
 			0x00, 0x08, // Property type.
-			0x00, 0x14, // Property length.
+			0x00, 0x0c, // Property length.
 		}, fieldsBytes...)},
 	}
 
@@ -189,7 +164,7 @@ func TestTablePropWildcards(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&TablePropWildcards{Fields: fields}, append([]byte{
 			0x00, 0x09, // Property type.
-			0x00, 0x14, // Property length.
+			0x00, 0x0c, // Property length.
 		}, fieldsBytes...)},
 	}
 
@@ -200,7 +175,7 @@ func TestTablePropWriteSetField(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&TablePropWriteSetField{Fields: fields}, append([]byte{
 			0x00, 0x0a, // Property type.
-			0x00, 0x14, // Property length.
+			0x00, 0x0c, // Property length.
 		}, fieldsBytes...)},
 	}
 
@@ -214,7 +189,7 @@ func TestTablePropApplySetField(t *testing.T) {
 			Fields: fields,
 		}, append([]byte{
 			0x00, 0x0d, // Property type.
-			0x00, 0x14, // Property length.
+			0x00, 0x0c, // Property length.
 		}, fieldsBytes...)},
 	}
 
@@ -247,16 +222,16 @@ func TestTableFeatures(t *testing.T) {
 	copy(name, []byte("table-1"))
 
 	properties := []TableProp{
-		&TablePropApplyActions{Actions: Actions{
-			&ActionGroup{Group: Group(3)},
+		&TablePropApplyActions{Actions: []ActionType{
+			ActionTypeGroup,
 		}},
-		&TablePropInstructions{Instructions: Instructions{
-			&InstructionMeter{Meter: Meter(4)},
+		&TablePropInstructions{Instructions: []InstructionType{
+			InstructionTypeMeter,
 		}},
 	}
 
 	bytes := []byte{
-		0x00, 0x60, // Length.
+		0x00, 0x50, // Length.
 		0x03,                         // Table identifier.
 		0x00, 0x00, 0x00, 0x00, 0x00, // 5-byte padding.
 	}
@@ -270,22 +245,16 @@ func TestTableFeatures(t *testing.T) {
 
 		// Properties.
 		0x00, 0x06, // Property type.
-		0x00, 0x0c, // Property length.
+		0x00, 0x08, // Property length.
 		// Actions.
 		0x00, 0x16, // Action type.
-		0x00, 0x08, // Action length.
-		0x00, 0x00, 0x00, 0x03, // Group identi0ier.
-		// Alignment.
-		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x04, // Action length.
 
 		0x00, 0x00, // Property type.
-		0x00, 0x0c, // Property length.
+		0x00, 0x08, // Property length.
 		// Instructions.
 		0x00, 0x06, // Instruction type.
-		0x00, 0x08, // Instruction length.
-		0x00, 0x00, 0x00, 0x04, // Meter identifier.
-		// Alignment.
-		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x04, // Instruction length.
 	)
 
 	tests := []encodingtest.MU{

--- a/test/topology/multilink.py
+++ b/test/topology/multilink.py
@@ -5,6 +5,7 @@ import mininet.net
 import mininet.topo
 import mininet.node
 import mininet.log
+import mininet.cli
 
 
 class Topo(mininet.topo.Topo):
@@ -27,12 +28,18 @@ class Topo(mininet.topo.Topo):
 def main():
     mininet.log.setLogLevel("info")
 
-    net = mininet.net.Mininet(topo=Topo())
-    net.addController(ip="127.0.0.1",
+    net = mininet.net.Mininet(
+        topo=Topo(),
+        switch=mininet.node.UserSwitch,
+        controller=None)
+
+    net.addController(
+        ip="127.0.0.1",
         controller=mininet.node.RemoteController)
 
-    set_default_route(net)
     net.start()
+    mininet.cli.CLI(net)
+    net.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch modifies the encoding and decoding implementation of the
OpenFlow table feature properties in order to comply with 1.3.1
specification. Unit tests updated appropriately, tested in conjuction
with LINC-Switch.

Added String functions to print a readable representation of the
few OpenFlow types.

closes #112 