### PR TITLE
Extended match helpers

### DIFF
--- a/ofp/flow.go
+++ b/ofp/flow.go
@@ -184,7 +184,7 @@ func NewFlowMod(c FlowModCommand, p *PacketIn) *FlowMod {
 	default:
 		// Use the overlap checking and flow removed notification
 		// flags by default for generated message.
-		flags = FlowFlagSendFlowRem | FlowFlagCheckOverlap
+		flags = FlowFlagSendFlowRem
 	}
 
 	// When the packet-in message was not provided into

--- a/ofp/flow_test.go
+++ b/ofp/flow_test.go
@@ -224,7 +224,7 @@ func TestNewFlowMod(t *testing.T) {
 
 	// Ensure that all default parameters of the created
 	// flow modification message have been defined.
-	if fmod.Flags^(FlowFlagSendFlowRem|FlowFlagCheckOverlap) != 0 {
+	if fmod.Flags^(FlowFlagSendFlowRem) != 0 {
 		t.Errorf("Default flags are not set: %b", fmod.Flags)
 	}
 

--- a/ofputil/match.go
+++ b/ofputil/match.go
@@ -24,11 +24,39 @@ func ExtendedMatch(xms ...ofp.XM) ofp.Match {
 	return ofp.Match{ofp.MatchTypeXM, xms}
 }
 
-func MatchInPort(port ofp.PortNo) ofp.XM {
+// basic creates an Openflow basic extensible match of the given type.
+func basic(t ofp.XMType, val ofp.XMValue, mask ofp.XMValue) ofp.XM {
 	return ofp.XM{
 		Class: ofp.XMClassOpenflowBasic,
-		Type:  ofp.XMTypeInPort,
-		Value: bytesOf(port),
-		Mask:  nil,
+		Type:  t, Value: val, Mask: mask,
 	}
+}
+
+// MatchEthType creates an Openflow basic extensible match of Ethernet
+// payload type.
+func MatchEthType(eth uint16) ofp.XM {
+	return basic(ofp.XMTypeEthType, bytesOf(eth), nil)
+}
+
+// MatchInPort creates an Openflow basic extensible match of in port.
+func MatchInPort(port ofp.PortNo) ofp.XM {
+	return basic(ofp.XMTypeInPort, bytesOf(port), nil)
+}
+
+// MatchIPPort creates an Openflow basic extensible match of IP protocol
+// payload type.
+func MatchIPProto(ipp uint8) ofp.XM {
+	return basic(ofp.XMTypeIPProto, bytesOf(ipp), nil)
+}
+
+// MatchICMPv6Type creates an Openflow basic extensible match of ICMPv6
+// message type.
+func MatchICMPv6Type(icmpt uint8) ofp.XM {
+	return basic(ofp.XMTypeICMPv6Type, bytesOf(icmpt), nil)
+}
+
+// MatchIPv6ExtHeader creates an Openflow basic extensible match of IPv6
+// extension header.
+func MatchIPv6ExtHeader(header uint16) ofp.XM {
+	return basic(ofp.XMTypeIPv6ExtHeader, bytesOf(header), nil)
 }


### PR DESCRIPTION
This patch introduces a few extended match helpers. It also removes
the overlap check as default flag for a new flow modification message.