### PR TITLE
Add barrier messages

### DIFF
--- a/header.go
+++ b/header.go
@@ -38,6 +38,10 @@ const (
 	TypeMultipartRequest
 	TypeMultipartReply
 
+    // Barrier messages
+    TypeBarrierRequest
+    TypeBarrierReply
+
 	// Queue configuration messages.
 	TypeQueueGetConfigRequest
 	TypeQueueGetConfigReply

--- a/header.go
+++ b/header.go
@@ -38,9 +38,9 @@ const (
 	TypeMultipartRequest
 	TypeMultipartReply
 
-        // Barrier messages
-        TypeBarrierRequest
-        TypeBarrierReply
+	// Barrier messages
+	TypeBarrierRequest
+	TypeBarrierReply
 
 	// Queue configuration messages.
 	TypeQueueGetConfigRequest

--- a/header.go
+++ b/header.go
@@ -38,9 +38,9 @@ const (
 	TypeMultipartRequest
 	TypeMultipartReply
 
-    // Barrier messages
-    TypeBarrierRequest
-    TypeBarrierReply
+        // Barrier messages
+        TypeBarrierRequest
+        TypeBarrierReply
 
 	// Queue configuration messages.
 	TypeQueueGetConfigRequest


### PR DESCRIPTION
Add Barrier Messages as per latest OF 1.3.5 version (https://www.opennetworking.org/images/stories/downloads/sdn-resources/onf-specifications/openflow/openflow-switch-v1.3.5.pdf page 51).

I believe this also fixes following message types (Queue, Role Request, etc...) because the message number is now in order.