### PR TITLE
Fix Table property types.

### DIFF
--- a/ofp/table.go
+++ b/ofp/table.go
@@ -229,10 +229,10 @@ const (
 	TablePropTypeMatch
 
 	// TablePropTypeWildcards indicates wildcards property.
-	TablePropTypeWildcards
+	TablePropTypeWildcards = 1 + iota
 
 	// TablePropTypeWriteSetField indicates write set-field property.
-	TablePropTypeWriteSetField
+	TablePropTypeWriteSetField = 2 + iota
 
 	// TablePropTypeWriteSetFieldMiss indicates write set-field property
 	// for table-miss.

--- a/ofp/table_test.go
+++ b/ofp/table_test.go
@@ -163,7 +163,7 @@ func TestTablePropMatch(t *testing.T) {
 func TestTablePropWildcards(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&TablePropWildcards{Fields: fields}, append([]byte{
-			0x00, 0x09, // Property type.
+			0x00, 0x0a, // Property type.
 			0x00, 0x0c, // Property length.
 		}, fieldsBytes...)},
 	}
@@ -174,7 +174,7 @@ func TestTablePropWildcards(t *testing.T) {
 func TestTablePropWriteSetField(t *testing.T) {
 	tests := []encodingtest.MU{
 		{&TablePropWriteSetField{Fields: fields}, append([]byte{
-			0x00, 0x0a, // Property type.
+			0x00, 0x0c, // Property type.
 			0x00, 0x0c, // Property length.
 		}, fieldsBytes...)},
 	}
@@ -188,7 +188,7 @@ func TestTablePropApplySetField(t *testing.T) {
 			Miss:   true,
 			Fields: fields,
 		}, append([]byte{
-			0x00, 0x0d, // Property type.
+			0x00, 0x0e, // Property type.
 			0x00, 0x0c, // Property length.
 		}, fieldsBytes...)},
 	}

--- a/ofp/table_test.go
+++ b/ofp/table_test.go
@@ -188,7 +188,7 @@ func TestTablePropApplySetField(t *testing.T) {
 			Miss:   true,
 			Fields: fields,
 		}, append([]byte{
-			0x00, 0x0e, // Property type.
+			0x00, 0x0f, // Property type.
 			0x00, 0x0c, // Property length.
 		}, fieldsBytes...)},
 	}


### PR DESCRIPTION
There are no property types 9 and 11 in Openflow 1.3.

closes #117 