### PR TITLE
Make net.go:conn Write thread safe.

### DIFF
--- a/net.go
+++ b/net.go
@@ -108,11 +108,15 @@ func (c *conn) Receive() (*Request, error) {
 
 // Write writes data to the connection. Write can be made to time out.
 func (c *conn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.buf.Write(b)
 }
 
 // Flush writes any buffered data to the connection.
 func (c *conn) Flush() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.buf.Flush()
 }
 


### PR DESCRIPTION
There may be more work into this, but in case I want to have a multi threaded app using Openflow.Send(...), the inner Write needs to be under a lock. I am assuming this was the initial intent anyway since the mutex already exists in the code.

closes #125