### PR TITLE
Introduce connection force write

### DIFF
--- a/net.go
+++ b/net.go
@@ -120,6 +120,19 @@ func (c *conn) Flush() error {
 	return c.buf.Flush()
 }
 
+// forceWrite writes given data and any buffered data to the connection.
+func (c *conn) forceWrite(b []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	_, err := c.buf.Write(b)
+	if err != nil {
+		return err
+	}
+
+	return c.buf.Flush()
+}
+
 // Send writes OpenFlow data to the connection.
 func (c *conn) Send(r *Request) error {
 	if d := c.WriteTimeout; d != 0 {

--- a/server.go
+++ b/server.go
@@ -86,12 +86,7 @@ func (r *response) Write(header *Header, w io.WriterTo) (err error) {
 		return
 	}
 
-	_, err = r.conn.Write(r.buf.Bytes())
-	if err != nil {
-		return
-	}
-
-	return r.conn.Flush()
+	return r.conn.forceWrite(r.buf.Bytes())
 }
 
 // The reqwrap defines a placeholder for request and error returned


### PR DESCRIPTION
This patch defines a new function for conn type that allows to write
and flush the data to the connection using a single mutex acquire.

Such approach should minimize context switches between go-routines,
which in general improves performance of multi-threaded applications.