### PR TITLE
padLen() was Computed Twice

### DIFF
--- a/ofp/match.go
+++ b/ofp/match.go
@@ -431,7 +431,7 @@ func (m *Match) ReadFrom(r io.Reader) (n int64, err error) {
 	}
 
 	// Read the padding after the list of extensible matches.
-	nn, err = encoding.ReadFrom(r, makePad(padLen(matchlen)))
+	nn, err = encoding.ReadFrom(r, makePad(matchlen))
 	return n + nn, err
 }
 


### PR DESCRIPTION
padLen() is computed internally by makePad(), so matchlen should be passed as-is.