### PR TITLE
Instructions' Actions not Available after Reading

### DIFF
--- a/ofp/action.go
+++ b/ofp/action.go
@@ -196,6 +196,7 @@ func (a *Actions) WriteTo(w io.Writer) (int64, error) {
 // the list of types that implement Action interface.
 func (a *Actions) ReadFrom(r io.Reader) (int64, error) {
 	var actionType ActionType
+	*a = nil
 
 	rm := func() (io.ReaderFrom, error) {
 		if rm, ok := actionMap[actionType]; ok {

--- a/ofp/instruction.go
+++ b/ofp/instruction.go
@@ -221,13 +221,13 @@ func writeInstructionActions(w io.Writer, t InstructionType,
 
 // readInstructionActions deserializes the instruction with actions.
 // It is shared among the Apply/Clear/Write instructions.
-func readInstructionActions(r io.Reader, actions Actions) (int64, error) {
+func readInstructionActions(r io.Reader, actions *Actions) (int64, error) {
 	var read int64
 
 	// Read the header of the instruction at first to retrieve
 	// the size of actions in the packet.
 	var header instruction
-	num, err := encoding.ReadFrom(r, &header)
+	num, err := encoding.ReadFrom(r, &header, &defaultPad4)
 	read += num
 
 	if err != nil {
@@ -236,7 +236,7 @@ func readInstructionActions(r io.Reader, actions Actions) (int64, error) {
 
 	// Limit the reader to the size of actions, so we could know
 	// where is the a border of the message.
-	limrd := io.LimitReader(r, int64(header.Len-4))
+	limrd := io.LimitReader(r, int64(header.Len-8))
 	num, err = actions.ReadFrom(limrd)
 	read += num
 
@@ -265,7 +265,7 @@ func (i *InstructionApplyActions) WriteTo(w io.Writer) (int64, error) {
 // ReadFrom implements io.ReadFrom interface. It deserializes
 // the instruction used to apply actions from the wire format.
 func (i *InstructionApplyActions) ReadFrom(r io.Reader) (int64, error) {
-	return readInstructionActions(r, i.Actions)
+	return readInstructionActions(r, &i.Actions)
 }
 
 // InstructionWriteActions represents a bundle of actions that should
@@ -290,7 +290,7 @@ func (i *InstructionWriteActions) WriteTo(w io.Writer) (int64, error) {
 // ReadFrom implements io.ReadFrom interface. It serializes instruction
 // used to write actions from the wire format.
 func (i *InstructionWriteActions) ReadFrom(r io.Reader) (int64, error) {
-	return readInstructionActions(r, i.Actions)
+	return readInstructionActions(r, &i.Actions)
 }
 
 // InstructionClearActions is an instruction used to clear the set


### PR DESCRIPTION
Fixes a bug where actions for instructions were not properly read due to using pass-by-value instead of pass-by-pointer for the action list.  

Also fixed a related bug where action lists' padding wasn't read, leading to an off-by-4 read error.