### PR TITLE
Add server concurrency model

### DIFF
--- a/responsewrite_test.go
+++ b/responsewrite_test.go
@@ -49,7 +49,7 @@ func TestResponseWrite(t *testing.T) {
 		resp.ReadFrom(r.Body)
 		features.ReadFrom(r.Body)
 
-		// Read only the first table feture.
+		// Read only the first table feature.
 		log.Println(features)
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -1,0 +1,30 @@
+package openflow
+
+// Runner describes types used to start a function according to the
+// defined concurrency model.
+type Runner interface {
+	Run(func())
+}
+
+// OnDemandRoutineRunner is a runner that start each function in a
+// separate go-routine. This handler is useful for initial prototyping,
+// but it is highly recommended to use runner with a fixed amount of
+// workers in order to prevent over go-routining.
+type OnDemandRoutineRunner struct{}
+
+// Run starts a function in a separate go-routine. This method implements
+// Runner interface.
+func (_ OnDemandRoutineRunner) Run(fn func()) {
+	go fn()
+}
+
+// SequentialRunner is a runner that starts each function one by one.
+// New function does not start execution until the previous one is done.
+//
+// This runner is useful for debugging purposes.
+type SequentialRunner struct{}
+
+// Run starts a function as is. This method implements Runner interface.
+func (_ SequentialRunner) Run(fn func()) {
+	fn()
+}

--- a/runner.go
+++ b/runner.go
@@ -6,10 +6,10 @@ type Runner interface {
 	Run(func())
 }
 
-// OnDemandRoutineRunner is a runner that start each function in a
-// separate go-routine. This handler is useful for initial prototyping,
+// OnDemandRoutineRunner is a runner that starts each function in a
+// separate goroutine. This handler is useful for initial prototyping,
 // but it is highly recommended to use runner with a fixed amount of
-// workers in order to prevent over go-routining.
+// workers in order to prevent over goroutining.
 type OnDemandRoutineRunner struct{}
 
 // Run starts a function in a separate go-routine. This method implements

--- a/server.go
+++ b/server.go
@@ -161,6 +161,11 @@ type Server struct {
 	// Addr is an address to listen on.
 	Addr string
 
+	// Runner defines concurrency model of handling requests from the
+	// switch within a single connection. By default OnDemandRoutineRunner
+	// is used.
+	Runner Runner
+
 	// Handler to invoke on the incoming requests.
 	Handler Handler
 
@@ -218,11 +223,16 @@ func (srv *Server) Serve(l net.Listener) error {
 		handler = DefaultMux
 	}
 
+	runner := srv.Runner
+	if runner == nil {
+		runner = OnDemandRoutineRunner{}
+	}
+
 	// Initialize a channel used to terminate the main handling loop.
 	srv.once.Do(func() { srv.stop = make(chan struct{}) })
 
 	for {
-		err := srv.accept(l, handler)
+		err := srv.accept(l, runner, handler)
 		if err != nil {
 			return err
 		}
@@ -232,7 +242,7 @@ func (srv *Server) Serve(l net.Listener) error {
 // The accept block until a new connection will be extracted from the
 // queue. It keeps track of count of incoming connections and closes all
 // that exceed the MaxConns threshold.
-func (srv *Server) accept(l net.Listener, h Handler) error {
+func (srv *Server) accept(l net.Listener, r Runner, h Handler) error {
 	rwc, err := l.Accept()
 	if err != nil {
 		return err
@@ -255,29 +265,30 @@ func (srv *Server) accept(l net.Listener, h Handler) error {
 	}
 
 	atomic.AddInt32(&srv.conns, 1)
-	go srv.serve(c, h)
+	go srv.serve(c, r, h)
 
 	return nil
 }
 
-func (srv *Server) serve(c *conn, h Handler) {
+func (srv *Server) serve(c *conn, r Runner, h Handler) {
 	// Define a deferred call to close the connection.
 	defer c.Close()
+	defer srv.setState(c, StateClosed)
 	rcvr := &receiver{Conn: c}
 
 	for {
 		select {
 		// Receive new requests in the infinite loop and handle them
-		// sequentially. When error is returned from the receive loop, this
-		// routine will be stopped and the client connection closed.
+		// according to the Runner algorithm. When error is returned
+		// from the receive loop, this routine will be stopped and the
+		// client connection closed.
 		case entry := <-rcvr.C():
 			if entry.err != nil {
 				atomic.AddInt32(&srv.conns, -1)
-				srv.setState(c, StateClosed)
 				return
 			}
 
-			srv.serveReq(c, entry.req, h)
+			r.Run(func() { srv.serveReq(c, entry.req, h) })
 
 		// Stop channel used here only for testing purposes to terminate the
 		// infinite receive loop. As a result the all client connections will


### PR DESCRIPTION
This patch defines an optional concurrency model of the Server to
handle the requests from a single connection.

Closes #134 