### PR TITLE
Add optional connection handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@
 language: go
 
 go:
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
+  - "1.7.x"
+  - "1.8.x"
+  - "1.9.x"
+  - "1.10.x"
+  - "1.11.x"
 
 notifications:
   email: false

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -43,7 +43,7 @@ func TestCookieReaderOf(t *testing.T) {
 	}
 
 	if jar.Cookies() != 42 {
-		t.Fatalf("Invalid cookie returned: %d", jar.Cookies)
+		t.Fatalf("Invalid cookie returned: %d", jar.Cookies())
 	}
 }
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -72,13 +72,13 @@ func TestTypeMux(t *testing.T) {
 	// it will return EOF, which will be used to identify the
 	// successful read of the message.
 	if err != io.EOF {
-		t.Errorf("Serve failed:", err)
+		t.Errorf("Serve failed: %v", err)
 	}
 
 	wg.Wait()
 
 	returned := fmt.Sprintf("%x", conn.w.Bytes())
 	if returned != "0400000c0000000000000000" {
-		t.Errorf("Invalid data returned: ", returned)
+		t.Errorf("Invalid data returned: %v", returned)
 	}
 }


### PR DESCRIPTION
This patch adds connection handler to customize the strategy of connections
handling.

Update the list of Go versions for testing.