### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/ofputil/match.go
+++ b/ofputil/match.go
@@ -43,7 +43,7 @@ func MatchInPort(port ofp.PortNo) ofp.XM {
 	return basic(ofp.XMTypeInPort, bytesOf(port), nil)
 }
 
-// MatchIPPort creates an Openflow basic extensible match of IP protocol
+// MatchIPProto creates an Openflow basic extensible match of IP protocol
 // payload type.
 func MatchIPProto(ipp uint8) ofp.XM {
 	return basic(ofp.XMTypeIPProto, bytesOf(ipp), nil)


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?